### PR TITLE
Fix edit field pre-population

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -10,7 +10,7 @@ class Character < ApplicationRecord
   validates :name, uniqueness: true, presence: true, length: { minimum: 2 }
   validates :dndbeyond_url, uniqueness: true, presence: true
   validates :character_class, presence: true, length: { minimum: 4 }
-  validates :species, presence: true, length: { minimum: 4 }
+  validates :species, presence: true, length: { minimum: 3 }
 
   # https://www.dndbeyond.com/classes
   def self.classes

--- a/app/views/characters/_form.html.erb
+++ b/app/views/characters/_form.html.erb
@@ -22,12 +22,12 @@
   </div>
 
   <div class="field">
-    <%= f.label 'Species' %>
+    <%= f.label 'species', 'Species' %>
     <%= f.select 'species', options_for_select(@species, @character.species), {required: true} %>
   </div>
 
   <div class="field">
-    <%= f.label 'Class' %>
+    <%= f.label 'character_class', 'Class' %>
     <%= f.select 'character_class', options_for_select(@classes, @character.character_class), {required: true} %>
   </div>
 

--- a/app/views/characters/_form.html.erb
+++ b/app/views/characters/_form.html.erb
@@ -23,12 +23,12 @@
 
   <div class="field">
     <%= f.label 'Species' %>
-    <%= f.select 'species', options_for_select(@species), {required: true} %>
+    <%= f.select 'species', options_for_select(@species, @character.species), {required: true} %>
   </div>
 
   <div class="field">
     <%= f.label 'Class' %>
-    <%= f.select 'character_class', options_for_select(@classes), {required: true} %>
+    <%= f.select 'character_class', options_for_select(@classes, @character.character_class), {required: true} %>
   </div>
 
   <div class="field">

--- a/spec/factories/character_factory.rb
+++ b/spec/factories/character_factory.rb
@@ -3,9 +3,9 @@ require 'faker'
 FactoryBot.define do
   factory :character do
     name { Faker::Games::WorldOfWarcraft.unique.hero }
-    species { "Humanoid (#{Faker::Games::DnD.species})" }
+    species { Character.species.drop(1).sample }
     level { Faker::Number.between(from: 1, to: 19).to_i+1 }
-    character_class { "#{Faker::Games::DnD.klass} Class" }
+    character_class { Character.classes.drop(1).sample }
     campaign
     user
     dndbeyond_url { "http://dndbeyond/#{Faker::Number.within(range: 100000..999999)}"}

--- a/spec/features/characters/character_creation_spec.rb
+++ b/spec/features/characters/character_creation_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature 'Character creation' do
       expect(page).to have_content("Character class can't be blank")
       expect(page).to have_content('Character class is too short (minimum is 4 characters)')
       expect(page).to have_content("Species can't be blank")
-      expect(page).to have_content('Species is too short (minimum is 4 characters)')
+      expect(page).to have_content('Species is too short (minimum is 3 characters)')
     end
 
     it 'fails when campaign is made inactive during the character creation' do

--- a/spec/features/characters/character_edit_spec.rb
+++ b/spec/features/characters/character_edit_spec.rb
@@ -20,6 +20,9 @@ RSpec.feature 'Character updating' do
         click_button 'Edit Character'
       end
 
+      expect(page).to have_select 'Species', selected: @character.species #, options: Character.species
+      expect(page).to have_select 'Class', selected: @character.character_class #, options: Character.classes
+
       fill_in :character_name, with: 'Cormyn'
       select 'Human', from: :character_species
       select 'Hunter', from: :character_character_class
@@ -78,7 +81,7 @@ RSpec.feature 'Character updating' do
       expect(page).to have_content("Character class can't be blank")
       expect(page).to have_content('Character class is too short (minimum is 4 characters)')
       expect(page).to have_content("Species can't be blank")
-      expect(page).to have_content('Species is too short (minimum is 4 characters)')
+      expect(page).to have_content('Species is too short (minimum is 3 characters)')
     end
 
     it 'does not succeed if a user tries to edit a character that is not theirs' do

--- a/spec/features/characters/character_edit_spec.rb
+++ b/spec/features/characters/character_edit_spec.rb
@@ -20,8 +20,8 @@ RSpec.feature 'Character updating' do
         click_button 'Edit Character'
       end
 
-      expect(page).to have_select 'Species', selected: @character.species #, options: Character.species
-      expect(page).to have_select 'Class', selected: @character.character_class #, options: Character.classes
+      expect(page).to have_select 'Species', selected: @character.species, options: Character.species
+      expect(page).to have_select 'Class', selected: @character.character_class, options: Character.classes
 
       fill_in :character_name, with: 'Cormyn'
       select 'Human', from: :character_species


### PR DESCRIPTION
Resolves #77

- Fixes Character Edit view so that "Species" and "Class" fields are pre-populated with existing character info
- Fixes select field labels so they are associated with select fields for test purposes
- Revises Character factory to pull from actual data now available in `Character.species` and `Character.classes`
- Lowers minimum character length of `species` to 3 in model validation so Orcses and Elves can play

![elves kissing orcs](https://media.giphy.com/media/C1sFA5mUnrzIQ/source.gif)