### PR TITLE
split species into three tables for ancestry and culture

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -83,12 +83,12 @@ class CharactersController < ApplicationController
   def prep_form_data
     @character = Character.new
     @user = current_user
+    @species = Culture.order(:name)
     @form_submission_url = user_characters_path(@user, @character)
-    @species = Character.species
     @classes = Character.classes
   end
 
   def character_params
-    params.require(:character).permit(:name, :level, :character_class, :species, :dndbeyond_url)
+    params.require(:character).permit(:name, :level, :klass, :ancestryone_id, :culture_id, :dndbeyond_url)
   end
 end

--- a/app/models/ancestryone.rb
+++ b/app/models/ancestryone.rb
@@ -1,0 +1,10 @@
+class Ancestryone < ApplicationRecord
+  # sync this EXACTLY with Ancestryone, Ancestrytwo, Culture
+
+  self.table_name = 'species'
+
+  validates :name, uniqueness: true, presence: true
+  validates :active, presence: true
+
+  has_many :characters
+end

--- a/app/models/ancestrytwo.rb
+++ b/app/models/ancestrytwo.rb
@@ -1,0 +1,10 @@
+class Ancestrytwo < ApplicationRecord
+  # sync this EXACTLY with Ancestryone, Ancestrytwo, Culture
+
+  self.table_name = 'species'
+
+  validates :name, uniqueness: true, presence: true
+  validates :active, presence: true
+
+  has_many :characters
+end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -6,26 +6,26 @@ class Character < ApplicationRecord
   has_many :item_characters
   has_many :items, through: :item_characters
 
+  belongs_to :ancestryone
+  belongs_to :ancestrytwo, optional: true
+  belongs_to :culture
+
   validates :level, presence: true, numericality: { only_integer: true, greater_than: 1, less_than_or_equal_to: 20 }
   validates :name, uniqueness: true, presence: true, length: { minimum: 2 }
   validates :dndbeyond_url, uniqueness: true, presence: true
-  validates :character_class, presence: true, length: { minimum: 4 }
-  validates :species, presence: true, length: { minimum: 3 }
+  validates :klass, presence: true, length: { minimum: 1 }
 
   scope :active, -> { where active: true }
 
-  # https://www.dndbeyond.com/classes
-  def self.classes
-    ['', 'Artificer', 'Barbarian', 'Bard', 'Blood Hunter', 'Cleric', 'Druid', 'Fighter', 'Monk', 'Paladin', 'Ranger',
-     'Rogue', 'Sorcerer', 'Warlock', 'Wizard']
+  def build_ancestry
+    ancestries = [ancestryone.name]
+    ancestries << ancestrytwo.name unless ancestrytwo.nil?
+    ancestries.join(' / ')
   end
 
-  # https://www.dndbeyond.com/races
-  def self.species
-    ['', 'Aarakocra', 'Aasimar', 'Bugbear', 'Centaur', 'Changeling', 'Dragonborn', 'Dwarf', 'Elf', 'Feral Tiefling',
-     'Firbolg', 'Genasi', 'Gith', 'Gnome', 'Goblin', 'Goliath', 'Grung', 'Half-Elf', 'Half-Orc', 'Halfling',
-     'Hobgoblin', 'Human', 'Kalashatar', 'Kenku', 'Kobold', 'Leonin', 'Lizardfolk', 'Locathah', 'Loxodon',
-     'Minotaur', 'Orc', 'Orc of Eberron', 'Orc of Exandria', 'Satyr', 'Shifter', 'Simic Hybrid', 'Tabaxi',
-     'Tiefling', 'Tortle', 'Triton', 'Vedalken', 'Verdan', 'Warforged', 'Yuan-ti Pureblood']
+  # https://www.dndbeyond.com/classes
+  def self.classes
+    ['Artificer', 'Barbarian', 'Bard', 'Blood Hunter', 'Cleric', 'Druid', 'Fighter', 'Monk', 'Paladin', 'Ranger',
+     'Rogue', 'Sorcerer', 'Warlock', 'Wizard']
   end
 end

--- a/app/models/culture.rb
+++ b/app/models/culture.rb
@@ -1,0 +1,10 @@
+class Culture < ApplicationRecord
+  # sync this EXACTLY with Ancestryone, Ancestrytwo, Culture
+
+  self.table_name = 'species'
+
+  validates :name, uniqueness: true, presence: true
+  validates :active, presence: true
+
+  has_many :characters
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   enum role: %w[default admin]
 
   def active_campaign_character
-    current_campaign =  Campaign.current
+    current_campaign = Campaign.current
     characters.where(campaign: current_campaign, active: true).first unless current_campaign.nil?
   end
 end

--- a/app/views/application/_character.html.erb
+++ b/app/views/application/_character.html.erb
@@ -4,7 +4,9 @@
       <%= character.name %>
     </h5>
     <h6 class="card-subtitle mb-2 text-muted">
-      <p><%= character.species %> <%= character.character_class %></p>
+      <p class="ancestry">Ancestry: <%= character.build_ancestry %></p>
+      <p class="culture">Culture: <%= character.culture.name %></p>
+      <p class="klass">Class: <%= character.klass %></p>
     </h6>
     <p>Level: <%= character.level %></p>
     <p>Active: <%= character.active %></p>

--- a/app/views/characters/_form.html.erb
+++ b/app/views/characters/_form.html.erb
@@ -10,7 +10,7 @@
       </ul>
     </div>
   <% end %>
-  
+
   <div class="field">
     <%= f.label :name %>
     <%= f.text_field :name, {required: true} %>
@@ -22,13 +22,21 @@
   </div>
 
   <div class="field">
-    <%= f.label 'species', 'Species' %>
-    <%= f.select 'species', options_for_select(@species, @character.species), {required: true} %>
+    <%= f.label 'ancestryone_id', 'Ancestry 1' %>
+    <%= f.collection_select :ancestryone_id, @species, :id, :name, prompt: true, required: true %>
+  </div>
+  <div class="field">
+    <%= f.label 'ancestrytwo_id', 'Ancestry 2 (optional)' %>
+    <%= f.collection_select :ancestrytwo_id, @species, :id, :name, prompt: true, include_blank: '(None)' %>
+  </div>
+  <div class="field">
+    <%= f.label 'culture_id', 'Culture' %>
+    <%= f.collection_select :culture_id, @species, :id, :name, prompt: true, required: true %>
   </div>
 
   <div class="field">
-    <%= f.label 'character_class', 'Class' %>
-    <%= f.select 'character_class', options_for_select(@classes, @character.character_class), {required: true} %>
+    <%= f.label 'klass', 'Class' %>
+    <%= f.select 'klass', options_for_select(@classes, @character.klass), prompt: true, required: true %>
   </div>
 
   <div class="field">

--- a/db/migrate/20200731045239_add_ancestry_culture_tables.rb
+++ b/db/migrate/20200731045239_add_ancestry_culture_tables.rb
@@ -1,0 +1,10 @@
+class AddAncestryCultureTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :species do |t|
+      t.string :name
+      t.boolean :active, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200731045240_change_characters_table.rb
+++ b/db/migrate/20200731045240_change_characters_table.rb
@@ -1,0 +1,10 @@
+class ChangeCharactersTable < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :characters, :character_class, :klass
+    remove_column :characters, :species
+
+    add_reference :characters, :ancestryone, null: false
+    add_reference :characters, :ancestrytwo, null: true
+    add_reference :characters, :culture, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_29_054326) do
+ActiveRecord::Schema.define(version: 2020_07_31_045240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,16 +34,21 @@ ActiveRecord::Schema.define(version: 2020_07_29_054326) do
 
   create_table "characters", force: :cascade do |t|
     t.string "name"
-    t.string "species"
     t.integer "level"
-    t.string "character_class"
+    t.string "klass"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "campaign_id", null: false
     t.bigint "user_id", null: false
     t.boolean "active", default: false
     t.string "dndbeyond_url"
+    t.bigint "ancestryone_id", null: false
+    t.bigint "ancestrytwo_id"
+    t.bigint "culture_id", null: false
+    t.index ["ancestryone_id"], name: "index_characters_on_ancestryone_id"
+    t.index ["ancestrytwo_id"], name: "index_characters_on_ancestrytwo_id"
     t.index ["campaign_id"], name: "index_characters_on_campaign_id"
+    t.index ["culture_id"], name: "index_characters_on_culture_id"
     t.index ["user_id"], name: "index_characters_on_user_id"
   end
 
@@ -104,6 +109,13 @@ ActiveRecord::Schema.define(version: 2020_07_29_054326) do
     t.string "additional_abilities"
     t.string "source"
     t.string "author"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "species", force: :cascade do |t|
+    t.string "name"
+    t.boolean "active", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,9 @@
 require 'csv'
+
+Character.delete_all
+Campaign.delete_all
+Monster.delete_all
+
 Campaign.create(name: 'Turing West Marches', status: 'active')
 array = CSV.read('./data/monsters.csv', headers: true)
 
@@ -25,4 +30,14 @@ array.each do |row|
                  additional_abilities: row['Additional'],
                  source: row['Font'],
                  author: row['Author'])
+end
+
+# Species list from https://www.dndbeyond.com/races including Eberron and some other books, approved by Mike
+Ancestryone.delete_all
+['Aarakocra', 'Aasimar', 'Bugbear', 'Centaur', 'Changeling', 'Dragonborn', 'Dwarf', 'Elf', 'Feral Tiefling',
+ 'Firbolg', 'Genasi', 'Gith', 'Gnome', 'Goblin', 'Goliath', 'Grung', 'Half-Elf', 'Half-Orc', 'Halfling',
+ 'Hobgoblin', 'Human', 'Kalashatar', 'Kenku', 'Kobold', 'Leonin', 'Lizardfolk', 'Locathah', 'Loxodon',
+ 'Minotaur', 'Orc', 'Orc of Eberron', 'Orc of Exandria', 'Satyr', 'Shifter', 'Simic Hybrid', 'Tabaxi',
+ 'Tiefling', 'Tortle', 'Triton', 'Vedalken', 'Verdan', 'Warforged', 'Yuan-ti Pureblood'].each do |species|
+  Ancestryone.create(name: species, active: true)
 end

--- a/spec/factories/campaign_factory.rb
+++ b/spec/factories/campaign_factory.rb
@@ -5,4 +5,8 @@ FactoryBot.define do
     name { Faker::Game.unique.title }
     status { 'active' }
   end
+  factory :inactive_campaign, parent: :campaign do
+    name { Faker::Game.unique.title }
+    status { 'inactive' }
+  end
 end

--- a/spec/factories/character_factory.rb
+++ b/spec/factories/character_factory.rb
@@ -3,12 +3,19 @@ require 'faker'
 FactoryBot.define do
   factory :character do
     name { "#{Faker::Games::WorldOfWarcraft.hero} #{Faker::Number.number(digits: 3)}" }
-    species { Character.species.drop(1).sample }
+    klass { Character.classes.drop(1).sample }
     level { Faker::Number.between(from: 1, to: 19).to_i+1 }
-    character_class { Character.classes.drop(1).sample }
-    campaign
-    user
     dndbeyond_url { "http://dndbeyond/#{Faker::Number.within(range: 100000..999999)}"}
     active { true }
+
+    ancestryone
+    ancestrytwo
+    culture
+    campaign
+    user
+  end
+
+  factory :inactive_character, parent: :character do
+    active { false }
   end
 end

--- a/spec/factories/species_factory.rb
+++ b/spec/factories/species_factory.rb
@@ -1,0 +1,18 @@
+require 'faker'
+
+FactoryBot.define do
+  factory :ancestryone, class: :Ancestryone do
+    name { "#{Faker::Games::Pokemon.name} #{Faker::Number.number(digits: 3)}" }
+    active { true }
+  end
+
+  factory :ancestrytwo, class: :Ancestrytwo do
+    name { "#{Faker::Games::Pokemon.name} #{Faker::Number.number(digits: 3)}" }
+    active { true }
+  end
+
+  factory :culture, class: :Culture do
+    name { "#{Faker::Games::Pokemon.name} #{Faker::Number.number(digits: 3)}" }
+    active { true }
+  end
+end

--- a/spec/features/characters/character_creation_spec.rb
+++ b/spec/features/characters/character_creation_spec.rb
@@ -21,8 +21,10 @@ RSpec.feature 'Character creation' do
         expect(current_path).to eq(new_user_character_path(@user))
 
         fill_in :character_name, with: 'Cormyn'
-        select 'Human', from: :character_species
-        select 'Hunter', from: :character_character_class
+        select 'Human', from: :character_ancestryone_id
+        select 'Gnome', from: :character_ancestrytwo_id
+        select 'Elf', from: :character_culture_id
+        select 'Hunter', from: :character_klass
         fill_in :character_level, with: 4
         fill_in :character_dndbeyond_url, with: 'http://dndbeyond.com/1234'
         click_button 'Create Character'
@@ -34,7 +36,12 @@ RSpec.feature 'Character creation' do
         within "#char-#{ch.id}" do
           expect(page).to have_content('Cormyn')
           expect(page).to have_content(ch.name)
-          expect(page).to have_content("#{ch.species} #{ch.character_class}")
+          within '.ancestry' do
+            expect(page).to have_content(ch.build_ancestry)
+          end
+          within '.klass' do
+            expect(page).to have_content(ch.klass)
+          end
           expect(page).to have_content("Level: #{ch.level}")
           expect(page).to have_content('Active: true')
         end
@@ -45,14 +52,16 @@ RSpec.feature 'Character creation' do
         visit new_user_character_path(@user)
 
         fill_in :character_name, with: 'Cormyn'
-        select 'Human', from: :character_species
-        select 'Hunter', from: :character_character_class
+        select 'Human', from: :character_ancestryone_id
+        select 'Gnome', from: :character_ancestrytwo_id
+        select 'Elf', from: :character_culture_id
+        select 'Hunter', from: :character_klass
         fill_in :character_level, with: 4
         fill_in :character_dndbeyond_url, with: 'http://dndbeyond.com/1234'
         click_button 'Create Character'
 
         # db lookup for expectations below
-        ch = Character.last
+        ch2 = Character.last
 
         expect(current_path).to eq(profile_path)
         within "#char-#{ch1.id}" do
@@ -60,8 +69,8 @@ RSpec.feature 'Character creation' do
           expect(page).to have_content('Active: true')
         end
 
-        within "#char-#{ch.id}" do
-          expect(page).to have_content(ch.name)
+        within "#char-#{ch2.id}" do
+          expect(page).to have_content(ch2.name)
           expect(page).to have_content('Active: false')
         end
       end
@@ -101,15 +110,15 @@ RSpec.feature 'Character creation' do
 
       expect(current_path).to eq(user_characters_path(@user))
       expect(page).to have_content('9 errors prohibited this character from being saved')
+      expect(page).to have_content('Ancestryone must exist')
+      expect(page).to have_content('Culture must exist')
+      expect(page).to have_content("Level can't be blank")
+      expect(page).to have_content('Level is not a number')
       expect(page).to have_content("Name can't be blank")
       expect(page).to have_content('Name is too short (minimum is 2 characters)')
       expect(page).to have_content("Dndbeyond url can't be blank")
-      expect(page).to have_content("Level can't be blank")
-      expect(page).to have_content('Level is not a number')
-      expect(page).to have_content("Character class can't be blank")
-      expect(page).to have_content('Character class is too short (minimum is 4 characters)')
-      expect(page).to have_content("Species can't be blank")
-      expect(page).to have_content('Species is too short (minimum is 3 characters)')
+      expect(page).to have_content("Klass can't be blank")
+      expect(page).to have_content('Klass is too short (minimum is 1 character)')
     end
 
     it 'fails when campaign is made inactive during the character creation' do
@@ -122,8 +131,10 @@ RSpec.feature 'Character creation' do
       @campaign.update!(status: 'inactive')
 
       fill_in :character_name, with: 'Cormyn'
-      select 'Human', from: :character_species
-      select 'Hunter', from: :character_character_class
+      select 'Human', from: :character_ancestryone_id
+      select 'Gnome', from: :character_ancestrytwo_id
+      select 'Elf', from: :character_culture_id
+      select 'Hunter', from: :character_klass
       fill_in :character_level, with: 4
       click_button 'Create Character'
 
@@ -141,8 +152,10 @@ RSpec.feature 'Character creation' do
       @campaign.delete
 
       fill_in :character_name, with: 'Cormyn'
-      select 'Human', from: :character_species
-      select 'Hunter', from: :character_character_class
+      select 'Human', from: :character_ancestryone_id
+      select 'Gnome', from: :character_ancestrytwo_id
+      select 'Elf', from: :character_culture_id
+      select 'Hunter', from: :character_klass
       fill_in :character_level, with: 4
       click_button 'Create Character'
 

--- a/spec/features/characters/user_can_see_characters_spec.rb
+++ b/spec/features/characters/user_can_see_characters_spec.rb
@@ -21,12 +21,22 @@ RSpec.describe 'character index', type: :feature do
 
           within "#char-#{@character_1.id}" do
             expect(page).to have_content(@character_1.name)
-            expect(page).to have_content("#{@character_1.species} #{@character_1.character_class}")
+            within '.ancestry' do
+              expect(page).to have_content(@character_1.build_ancestry)
+            end
+            within '.klass' do
+              expect(page).to have_content("Class: #{@character_1.klass}")
+            end
             expect(page).to have_content("Level: #{@character_1.level}")
           end
           within "#char-#{@character_2.id}" do
             expect(page).to have_content(@character_2.name)
-            expect(page).to have_content("#{@character_2.species} #{@character_2.character_class}")
+            within '.ancestry' do
+              expect(page).to have_content(@character_2.build_ancestry)
+            end
+            within '.klass' do
+              expect(page).to have_content("Class: #{@character_2.klass}")
+            end
             expect(page).to have_content("Level: #{@character_2.level}")
           end
 

--- a/spec/features/profile_page/user_profile_page_spec.rb
+++ b/spec/features/profile_page/user_profile_page_spec.rb
@@ -23,19 +23,34 @@ RSpec.describe 'As a visitor', type: :feature do
 
       within "#char-#{@character_1.id}" do
         expect(page).to have_content(@character_1.name)
-        expect(page).to have_content("#{@character_1.species} #{@character_1.character_class}")
+        within '.ancestry' do
+          expect(page).to have_content(@character_1.build_ancestry)
+        end
+        within '.klass' do
+          expect(page).to have_content("Class: #{@character_1.klass}")
+        end
         expect(page).to have_content("Level: #{@character_1.level}")
         expect(page).to have_content("Active: #{@character_1.active}")
       end
       within "#char-#{@character_2.id}" do
         expect(page).to have_content(@character_2.name)
-        expect(page).to have_content("#{@character_2.species} #{@character_2.character_class}")
+        within '.ancestry' do
+          expect(page).to have_content(@character_2.build_ancestry)
+        end
+        within '.klass' do
+          expect(page).to have_content(@character_2.klass)
+        end
         expect(page).to have_content("Level: #{@character_2.level}")
         expect(page).to have_content("Active: #{@character_2.active}")
       end
       within "#char-#{@character_3.id}" do
         expect(page).to have_content(@character_3.name)
-        expect(page).to have_content("#{@character_3.species} #{@character_3.character_class}")
+        within '.ancestry' do
+          expect(page).to have_content(@character_3.build_ancestry)
+        end
+        within '.klass' do
+          expect(page).to have_content(@character_3.klass)
+        end
         expect(page).to have_content("Level: #{@character_3.level}")
         expect(page).to have_content("Active: #{@character_3.active}")
       end

--- a/spec/models/ancestry_culture_spec.rb
+++ b/spec/models/ancestry_culture_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Ancestryone, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+    it { should validate_uniqueness_of(:name) }
+    it { should validate_presence_of(:active) }
+  end
+  describe 'relationships' do
+    it { should have_many :characters }
+  end
+end
+
+RSpec.describe Ancestrytwo, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+    it { should validate_uniqueness_of(:name) }
+    it { should validate_presence_of(:active) }
+  end
+  describe 'relationships' do
+    it { should have_many :characters }
+  end
+end
+
+RSpec.describe Culture, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+    it { should validate_uniqueness_of(:name) }
+    it { should validate_presence_of(:active) }
+  end
+  describe 'relationships' do
+    it { should have_many :characters }
+  end
+end

--- a/spec/models/factorybot_spec.rb
+++ b/spec/models/factorybot_spec.rb
@@ -4,7 +4,12 @@ RSpec.describe 'FactoryBot Factories' do
   it 'ensures all factories can be instantiated' do
     create(:adventure_log)
     create(:campaign)
+    create(:inactive_campaign)
+    create(:ancestryone)
+    create(:ancestrytwo)
+    create(:culture)
     create(:character)
+    create(:inactive_character)
     create(:game_session_character)
     create(:game_session)
     create(:item_character)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,10 +58,10 @@ RSpec.describe User, type: :model do
       before :each do
         @campaign = create(:campaign)
         @user = create(:user)
-        @inactive_character = create(:character, user: @user, campaign: @campaign, active: false)
-        @active_character = create(:character, user: @user, campaign: @campaign, active: true)
+        @inactive_character = create(:inactive_character, user: @user, campaign: @campaign)
+        @active_character = create(:character, user: @user, campaign: @campaign)
       end
-      
+
       it 'succeeds for happy path conditions' do
         expect(@user.active_campaign_character).to eq(@active_character)
         expect(@user.active_campaign_character).to_not eq(@inactive_character)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,6 +76,15 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  #
+  config.before :suite do
+    Culture.delete_all
+    Rails.application.load_seed
+    Campaign.delete_all
+  end
+  config.after :suite do
+    Culture.delete_all
+  end
 end
 
 def login_as_user(username, password)


### PR DESCRIPTION
closes #81 

This was a PITA to get working. I tried several ways to try making a single Species table and referencing/aliasing it every way I could find in docs/examples and it kept complaining either in the code or in factorybot, so in the end I made three models which all point to the same database table.

I also renamed `character.character_class` to `character.klass`... I'll add another github issue to make some friendly validation messages when things aren't chosen properly.