### PR TITLE
Allow level 1 chars

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -10,7 +10,7 @@ class Character < ApplicationRecord
   belongs_to :ancestrytwo, optional: true
   belongs_to :culture
 
-  validates :level, presence: true, numericality: { only_integer: true, greater_than: 1, less_than_or_equal_to: 20 }
+  validates :level, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 20 }
   validates :name, uniqueness: true, presence: true, length: { minimum: 2 }
   validates :dndbeyond_url, uniqueness: true, presence: true
   validates :klass, presence: true

--- a/spec/factories/character_factory.rb
+++ b/spec/factories/character_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :character do
     name { "#{Faker::Games::WorldOfWarcraft.hero} #{Faker::Number.number(digits: 3)}" }
     klass { Character.classes.drop(1).sample }
-    level { Faker::Number.between(from: 1, to: 19).to_i+1 }
+    level { Faker::Number.between(from: 1, to: 20).to_i }
     dndbeyond_url { "https://dndbeyond/#{Faker::Number.within(range: 100000..999999)}"}
     active { true }
 

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -62,9 +62,9 @@ RSpec.describe Character, type: :model do
 
       it 'validates that level is an integer between 1 and 20 because shoulda_matchers is being a jerk' do
         begin
-          @c3 = create(:character, user: @user, campaign: @campaign, level: -1)
+          @c3 = create(:character, user: @user, campaign: @campaign, level: 0)
         rescue ActiveRecord::RecordInvalid => e
-          expect(e.message).to eq('Validation failed: Your character level must be greater than 1')
+          expect(e.message).to eq('Validation failed: Your character level must be greater than or equal to 1')
         end
         expect(@c3).to be_a(NilClass)
 
@@ -74,6 +74,12 @@ RSpec.describe Character, type: :model do
           expect(e.message).to eq('Validation failed: Your character level must be less than or equal to 20')
         end
         expect(@c3).to be_a(NilClass)
+
+        c4 = create(:character, level: 1)
+        c5 = create(:character, level: 20)
+        
+        expect(c4).to be_a(Character)
+        expect(c5).to be_a(Character)
       end
     end
   end


### PR DESCRIPTION
Resolves #91 

Quick fix to character level validation to allow level 1 characters. Also updated character factory and added some tests to check inside/outside boundaries of validation range.

![mario level 1:1](https://media.giphy.com/media/TrhpJt1hFqgCI/source.gif)