### PR TITLE
Admin dashboard link

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   helper_method :current_user,
-                :current_campaign
+                :current_campaign,
+                :current_admin?
 
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,9 @@
 
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav mr-auto">
+          <% if current_admin? %>
+            <li class="nav-item"><%= link_to 'Admin Dashboard', admin_dashboard_path, class: 'nav-link' %></li>
+          <% end %>
           <% if current_user %>
             <li class="nav-item"><%= link_to 'Profile', profile_path, class: 'nav-link' %></li>
             <li class="nav-item"><%= link_to 'Log Out', logout_path, method: 'delete', class: 'nav-link' %></li>

--- a/spec/features/admin/admin_can_see_link_to_dashboard_spec.rb
+++ b/spec/features/admin/admin_can_see_link_to_dashboard_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'admin dashboard link', type: :feature do
+  context 'As a logged-in admin' do
+    before do
+      admin = create(:admin_user)
+      login_as_user(admin.username, admin.password)
+    end
+
+    context 'when I am on any page' do
+      it 'I can see a link on the navbar which links to the admin dashboard' do
+        # representative sampling; link is on site-wide view
+        paths = %w{/ /profile /monsters /characters}
+
+        paths.each do |path|
+          visit path
+          within '.navbar-nav' do
+            expect(page).to have_link('Admin Dashboard', href: '/admin/dashboard')
+          end
+        end
+      end
+
+      it 'I can click the admin dashboard link and be taken to it' do
+        visit '/'
+        click_on 'Admin Dashboard'
+        expect(current_path).to eq '/admin/dashboard'
+      end
+    end
+  end
+
+  context 'As a normal user' do
+    before do
+      user = create(:user)
+      login_as_user(user.username, user.password)
+    end
+
+    context 'when I am on any page' do
+      it 'I do not see navbar link to admin dashboard' do
+        visit '/'
+        refute_admin_link_presence
+      end
+    end
+  end
+
+  context 'As a visitor' do
+    context 'when I am on any page' do
+      it 'I do not see navbar link to admin dashboard' do
+        visit '/'
+        refute_admin_link_presence
+      end
+    end
+  end
+end
+
+def refute_admin_link_presence
+  within '.navbar-nav' do
+    expect(page).not_to have_link('Admin Dashboard')
+  end
+end


### PR DESCRIPTION
Resolves #89 

<img width="518" alt="Screen Shot 2020-08-01 at 12 14 10 PM" src="https://user-images.githubusercontent.com/40702808/89107773-88dcb980-d3f0-11ea-897b-ffd6cbf2b56e.png">

- Adds link to admin dashboard to navbar visible only to admin users
- Creates test to make it so

![1589172825454](https://user-images.githubusercontent.com/40702808/89107859-36e86380-d3f1-11ea-8fe7-189dd600a2a6.gif)