### PR TITLE
Game Session and Adventure Log Improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+AllCops:
+  Exclude:
+    - '/db/**/*'
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,6 @@ Style/Documentation:
 
 Style/ClassAndModuleChildren:
   Enabled: false
+
+Style/RegexpLiteral:
+  EnforcedStyle: slashes

--- a/app/controllers/adventure_logs_controller.rb
+++ b/app/controllers/adventure_logs_controller.rb
@@ -7,7 +7,7 @@ class AdventureLogsController < ApplicationController
   def create
     AdventureLog.create(content: content,
                         game_session_id: game_session_id,
-                        user: current_user)
+                        character: current_user.active_campaign_character)
     redirect_to game_session_path(game_session_id)
   end
 

--- a/app/models/adventure_log.rb
+++ b/app/models/adventure_log.rb
@@ -1,4 +1,4 @@
 class AdventureLog < ApplicationRecord
-  belongs_to :user
+  belongs_to :character
   belongs_to :game_session
 end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -5,6 +5,7 @@ class Character < ApplicationRecord
   has_many :game_sessions, through: :game_session_characters
   has_many :item_characters
   has_many :items, through: :item_characters
+  has_many :adventure_logs
 
   belongs_to :ancestryone
   belongs_to :ancestrytwo, optional: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,6 @@ class User < ApplicationRecord
   has_secure_password
 
   has_many :characters
-  has_many :adventure_logs
 
   enum role: %w[default admin]
 

--- a/app/views/game_sessions/show.html.erb
+++ b/app/views/game_sessions/show.html.erb
@@ -26,7 +26,7 @@
       <p class="adventure-log" id="adventure-log-<%= adventure_log.id %>">
         <%= adventure_log.content %>
         <cite class="adventure-log-citation">
-          By <%= adventure_log.user.active_campaign_character.name %>,
+          By <%= adventure_log.character.name %>,
           <%= adventure_log.created_at.strftime("%D, %r") %>
         </cite>
       </p>

--- a/app/views/game_sessions/show.html.erb
+++ b/app/views/game_sessions/show.html.erb
@@ -10,8 +10,26 @@
   <% end %>
 </ul>
 
-<%= link_to 'Create New Adventure Log', "/game_sessions/#{@game_session.id}/adventure_logs/new" %>
-
-<% @game_session.adventure_logs.each do |adventure_log| %>
-  <p><%= adventure_log.content %></p>
+<h3>Adventure Logs</h3>
+<p>
+  <%= link_to 'Create New Adventure Log',
+              "/game_sessions/#{@game_session.id}/adventure_logs/new" %>
+</p>
+<% if @game_session.adventure_logs.empty? %>
+  <p id="no-logs-message">
+    There aren't any adventure logs yet, but they'll appear here.
+    Click the link above to create the first!
+  </p>
+<% else %>
+  <section id="adventure-logs">
+    <% @game_session.adventure_logs.each do |adventure_log| %>
+      <p class="adventure-log" id="adventure-log-<%= adventure_log.id %>">
+        <%= adventure_log.content %>
+        <cite class="adventure-log-citation">
+          By <%= adventure_log.user.active_campaign_character.name %>,
+          <%= adventure_log.created_at.strftime("%D, %r") %>
+        </cite>
+      </p>
+    <% end %>
+  </section>
 <% end %>

--- a/app/views/game_sessions/show.html.erb
+++ b/app/views/game_sessions/show.html.erb
@@ -6,19 +6,32 @@
 <ul>
   <% @game_session.characters.each do |character| %>
     <li> <%= character.name %> </li>
-
   <% end %>
 </ul>
 
 <h3>Adventure Logs</h3>
-<p>
-  <%= link_to 'Create New Adventure Log',
-              "/game_sessions/#{@game_session.id}/adventure_logs/new" %>
-</p>
+
+<% if current_user &&
+   @game_session.characters.include?(current_user.active_campaign_character) %>
+  <p>
+    <%= link_to 'Create New Adventure Log',
+                "/game_sessions/#{@game_session.id}/adventure_logs/new" %>
+  </p>
+<% elsif current_user %>
+  <p id="non-participating-user-message">
+    (Only users with active participating characters can create adventure logs.)
+  </p>
+<% else %>
+  <p id="visitor-message">
+    (Log in <%= link_to 'with a password', login_path %> or 
+    <%= link_to 'using passwordless login', passwordless_login_path %>
+    to create a new adventure log.)
+  </p>
+<% end %>
+
 <% if @game_session.adventure_logs.empty? %>
   <p id="no-logs-message">
     There aren't any adventure logs yet, but they'll appear here.
-    Click the link above to create the first!
   </p>
 <% else %>
   <section id="adventure-logs">

--- a/db/migrate/20200802024757_add_character_id_to_adventure_logs_table.rb
+++ b/db/migrate/20200802024757_add_character_id_to_adventure_logs_table.rb
@@ -1,0 +1,6 @@
+class AddCharacterIdToAdventureLogsTable < ActiveRecord::Migration[6.0]
+  def change
+    remove_reference :adventure_logs, :user, index: true, foreign_key: true
+    add_reference :adventure_logs, :character, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_31_045240) do
+ActiveRecord::Schema.define(version: 2020_08_02_024757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,9 +20,9 @@ ActiveRecord::Schema.define(version: 2020_07_31_045240) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "game_session_id", null: false
-    t.bigint "user_id", null: false
+    t.bigint "character_id", null: false
+    t.index ["character_id"], name: "index_adventure_logs_on_character_id"
     t.index ["game_session_id"], name: "index_adventure_logs_on_game_session_id"
-    t.index ["user_id"], name: "index_adventure_logs_on_user_id"
   end
 
   create_table "campaigns", force: :cascade do |t|
@@ -135,8 +135,8 @@ ActiveRecord::Schema.define(version: 2020_07_31_045240) do
     t.index ["login_uuid"], name: "index_users_on_login_uuid"
   end
 
+  add_foreign_key "adventure_logs", "characters"
   add_foreign_key "adventure_logs", "game_sessions"
-  add_foreign_key "adventure_logs", "users"
   add_foreign_key "characters", "campaigns"
   add_foreign_key "characters", "users"
   add_foreign_key "game_session_characters", "characters"

--- a/spec/factories/adventure_log_factory.rb
+++ b/spec/factories/adventure_log_factory.rb
@@ -3,7 +3,7 @@ require 'faker'
 FactoryBot.define do
   factory :adventure_log do
     content { 3.times.map{Faker::Movie.quote}.join(' ') }
-    user
+    character
     game_session
   end
 end

--- a/spec/features/adventure_logs/user_can_create_adventure_log_for_a_game_session_spec.rb
+++ b/spec/features/adventure_logs/user_can_create_adventure_log_for_a_game_session_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe 'adventure log creation', type: :feature do
 
         expect(current_path).to eq(game_session_path(game_session))
         within '#adventure-logs' do
-          within ".adventure-log:first-of-type" do
+          within '.adventure-log:first-of-type' do
             expect(page).to have_content('Things happened')
           end
-          within ".adventure-log-citation" do
+          within '.adventure-log-citation' do
             expect(page).to have_content "By #{character.name}"
-            expect(page).to have_content /\d\d\/\d\d\/\d\d, \d\d:\d\d:\d\d [AP]{1}M/
+            expect(page).to have_content(/\d\d\/\d\d\/\d\d, \d\d:\d\d:\d\d [AP]{1}M/)
           end
         end
       end

--- a/spec/features/adventure_logs/user_can_create_adventure_log_for_a_game_session_spec.rb
+++ b/spec/features/adventure_logs/user_can_create_adventure_log_for_a_game_session_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'adventure log creation', type: :feature do
       end
     end
 
-    context 'when I visit a game session I don't have an active character in' do
+    context "when I visit a game session I don't have an active character in" do
       it 'I cannot create a log for that session but see message why' do
         visit game_session_path(@game_session)
 

--- a/spec/features/adventure_logs/user_can_create_adventure_log_for_a_game_session_spec.rb
+++ b/spec/features/adventure_logs/user_can_create_adventure_log_for_a_game_session_spec.rb
@@ -1,38 +1,72 @@
 require 'rails_helper'
 
 RSpec.describe 'adventure log creation', type: :feature do
-  context 'as a default user' do
-    context 'when I visit a game session' do
-      it 'I can create a new adventure log for that session' do
-        campaign = create(:campaign)
-        user = User.create(username:  'regular user',
-                           password:  'password',
-                           email:     'user@example.com',
-                           role:      0)
-        character = create(:character, campaign: campaign, user: user)
-        game_session = GameSession.create(name:      'great session',
-                                          campaign:  campaign)
-        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+  before do
+    @campaign = create(:campaign)
+    @game_session = GameSession.create(name:      'great session',
+                                       campaign:  @campaign)
+  end
 
-        visit game_session_path(game_session)
+  context 'as a visitor' do
+    context 'when I visit a game session' do
+      it 'I cannot create a log for that session but see links to log in' do
+        visit game_session_path(@game_session)
+
+        expect(page).not_to have_link('Create New Adventure Log')
+        within '#visitor-message' do
+          expect(page).to have_link('with a password', href: login_path)
+          expect(page).to have_link('using passwordless login',
+                                    href: passwordless_login_path)
+        end
+      end
+    end
+  end
+
+  context 'as a default user' do
+    before do
+      user = User.create(username:  'regular user',
+                          password:  'password',
+                          email:     'user@example.com',
+                          role:      0)
+      @character = create(:character, campaign: @campaign, user: user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    end
+
+    context 'when I visit a game session I have an active character in' do
+      before do
+        GameSessionCharacter.create(game_session: @game_session,
+                                    character: @character)
+      end
+
+      it 'I can create a new adventure log for that session' do
+        visit game_session_path(@game_session)
 
         click_link 'Create New Adventure Log'
 
-        expect(current_path).to eq(new_game_session_adventure_log_path(game_session))
+        expect(current_path).to eq(new_game_session_adventure_log_path(@game_session))
 
         fill_in 'Content', with: 'Things happened'
         click_on 'Create Adventure Log'
 
-        expect(current_path).to eq(game_session_path(game_session))
+        expect(current_path).to eq(game_session_path(@game_session))
         within '#adventure-logs' do
           within '.adventure-log:first-of-type' do
             expect(page).to have_content('Things happened')
           end
           within '.adventure-log-citation' do
-            expect(page).to have_content "By #{character.name}"
+            expect(page).to have_content "By #{@character.name}"
             expect(page).to have_content(/\d\d\/\d\d\/\d\d, \d\d:\d\d:\d\d [AP]{1}M/)
           end
         end
+      end
+    end
+
+    context 'when I visit a game session I don't have an active character in' do
+      it 'I cannot create a log for that session but see message why' do
+        visit game_session_path(@game_session)
+
+        expect(page).not_to have_link('Create New Adventure Log')
+        expect(page).to have_selector('#non-participating-user-message')
       end
     end
   end

--- a/spec/features/adventure_logs/user_can_create_adventure_log_for_a_game_session_spec.rb
+++ b/spec/features/adventure_logs/user_can_create_adventure_log_for_a_game_session_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe 'adventure log creation', type: :feature do
   context 'as a default user' do
     before do
       user = User.create(username:  'regular user',
-                          password:  'password',
-                          email:     'user@example.com',
-                          role:      0)
+                         password:  'password',
+                         email:     'user@example.com',
+                         role:      0)
       @character = create(:character, campaign: @campaign, user: user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
     end

--- a/spec/features/adventure_logs/user_can_create_adventure_log_for_a_game_session_spec.rb
+++ b/spec/features/adventure_logs/user_can_create_adventure_log_for_a_game_session_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'adventure log creation', type: :feature do
 
         visit game_session_path(game_session)
 
-        click_link "Create New Adventure Log"
+        click_link 'Create New Adventure Log'
 
         expect(current_path).to eq(new_game_session_adventure_log_path(game_session))
 
@@ -24,7 +24,15 @@ RSpec.describe 'adventure log creation', type: :feature do
         click_on 'Create Adventure Log'
 
         expect(current_path).to eq(game_session_path(game_session))
-        expect(page).to have_content('Things happened')
+        within '#adventure-logs' do
+          within ".adventure-log:first-of-type" do
+            expect(page).to have_content('Things happened')
+          end
+          within ".adventure-log-citation" do
+            expect(page).to have_content "By #{character.name}"
+            expect(page).to have_content /\d\d\/\d\d\/\d\d, \d\d:\d\d:\d\d [AP]{1}M/
+          end
+        end
       end
     end
   end

--- a/spec/models/adventure_log_spec.rb
+++ b/spec/models/adventure_log_spec.rb
@@ -3,6 +3,6 @@ require 'rails_helper'
 RSpec.describe AdventureLog, type: :model do
   describe 'relationships' do
     it { should belong_to :game_session }
-    it { should belong_to :user }
+    it { should belong_to :character }
   end
 end

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Character, type: :model do
     it { should belong_to(:ancestrytwo).optional }
     it { should belong_to(:culture) }
     it { should have_many(:items).through(:item_characters) }
+    it { should have_many :adventure_logs }
   end
 
   describe 'validations' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   describe 'relationships' do
     it { should have_many :characters }
-    it { should have_many :adventure_logs }
   end
 
   describe 'validations' do


### PR DESCRIPTION
## Issues

Resolves #95 and resolves #103 and resolves #56.

## Changes

- Adds header to adventure log section of game session show page
- Adds author citation and date to each adventure log rendered
- Changes adventure log relationships so that it belongs to a character instead of a user (see #103 for rationale)
- Makes link to create new adventure log render conditionally upon user being logged in and having an active character participating in the session.
- Logged-in users without participating characters in session see message to that effect, and no link.
- Visitors see message and links prompting them to log in.

## Screenshots

- With no logs:
  <img width="788" alt="Screen Shot 2020-08-01 at 1 20 35 PM" src="https://user-images.githubusercontent.com/40702808/89109724-14f6dd00-d401-11ea-9656-378141aa8c4e.png">

- With logs:
  <img width="1020" alt="Screen Shot 2020-08-01 at 1 49 03 PM" src="https://user-images.githubusercontent.com/40702808/89109725-17f1cd80-d401-11ea-9fb3-4dae96b7d938.png">

- Visitor:
  <img width="909" alt="Screen Shot 2020-08-01 at 10 23 09 PM" src="https://user-images.githubusercontent.com/40702808/89115865-6f685b80-d44a-11ea-9fa9-0c44de9229af.png">

- User with no participating characters:
  <img width="605" alt="Screen Shot 2020-08-01 at 11 00 00 PM" src="https://user-images.githubusercontent.com/40702808/89115887-bc4c3200-d44a-11ea-9c7f-f9b68dadeeb2.png">


## State of tests

```
....................................................................................................................

Finished in 5.85 seconds (files took 3.9 seconds to load)
116 examples, 0 failures

Coverage report generated for RSpec to /Users/dframpton/code/projects/cobalt_reserve/coverage. 1272 / 1272 LOC (100.0%) covered.
```

## GIF tax

![dog adventure](https://media.giphy.com/media/2579DBoBNLM1qBs2zV/giphy-downsized.gif)
