### PR TITLE
Create Adventure Log happy/sad path messaging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,6 @@ Style/ClassAndModuleChildren:
 
 Style/RegexpLiteral:
   EnforcedStyle: slashes
+
+Style/AndOr:
+  EnforcedStyle: conditionals

--- a/app/controllers/adventure_logs_controller.rb
+++ b/app/controllers/adventure_logs_controller.rb
@@ -14,7 +14,7 @@ class AdventureLogsController < ApplicationController
     else
       flash[:error] = adventure_log.errors.full_messages.join(', ')
       redirect_back fallback_location: new_game_session_adventure_log_path(game_session_id)
-    end 
+    end
   end
 
   private

--- a/app/controllers/adventure_logs_controller.rb
+++ b/app/controllers/adventure_logs_controller.rb
@@ -5,10 +5,16 @@ class AdventureLogsController < ApplicationController
   end
 
   def create
-    AdventureLog.create(content: content,
-                        game_session_id: game_session_id,
-                        character: current_user.active_campaign_character)
-    redirect_to game_session_path(game_session_id)
+    adventure_log = AdventureLog.new(content: content,
+                                     game_session_id: game_session_id,
+                                     character: current_user.active_campaign_character)
+    if adventure_log.save
+      flash[:success] = 'Your adventure log was created.'
+      redirect_to game_session_path(game_session_id) and return
+    else
+      flash[:error] = adventure_log.errors.full_messages.join(', ')
+      redirect_back fallback_location: new_game_session_adventure_log_path(game_session_id)
+    end 
   end
 
   private

--- a/app/models/adventure_log.rb
+++ b/app/models/adventure_log.rb
@@ -1,4 +1,6 @@
 class AdventureLog < ApplicationRecord
   belongs_to :character
   belongs_to :game_session
+
+  validates_length_of :content, minimum: 1
 end

--- a/app/views/adventure_logs/new.html.erb
+++ b/app/views/adventure_logs/new.html.erb
@@ -1,6 +1,6 @@
 <h1>Create Adventure Log</h1>
 
-<%= form_with model: [@game_session, @adventure_log] do |form| %>
+<%= form_with model: [@game_session, @adventure_log], local: true do |form| %>
   <%= form.label :content %>
   <%= form.text_area :content %>
 

--- a/spec/features/adventure_logs/user_can_create_adventure_log_for_a_game_session_spec.rb
+++ b/spec/features/adventure_logs/user_can_create_adventure_log_for_a_game_session_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe 'adventure log creation', type: :feature do
         click_on 'Create Adventure Log'
 
         expect(current_path).to eq(game_session_path(@game_session))
+        expect(page).to have_content 'Your adventure log was created.'
         within '#adventure-logs' do
           within '.adventure-log:first-of-type' do
             expect(page).to have_content('Things happened')
@@ -58,6 +59,15 @@ RSpec.describe 'adventure log creation', type: :feature do
             expect(page).to have_content(/\d\d\/\d\d\/\d\d, \d\d:\d\d:\d\d [AP]{1}M/)
           end
         end
+      end
+
+      it 'I cannot create a blank adventure log' do
+        visit game_session_path(@game_session)
+        click_link 'Create New Adventure Log'
+        click_on 'Create Adventure Log'
+
+        expect(current_path).to eq(new_game_session_adventure_log_path(@game_session))
+        expect(page).to have_content 'Content is too short (minimum is 1 character)'
       end
     end
 

--- a/spec/models/adventure_log_spec.rb
+++ b/spec/models/adventure_log_spec.rb
@@ -5,4 +5,8 @@ RSpec.describe AdventureLog, type: :model do
     it { should belong_to :game_session }
     it { should belong_to :character }
   end
+
+  describe 'validations' do
+    it { should validate_length_of(:content).is_at_least(1) }
+  end
 end


### PR DESCRIPTION
## Issues

Resolves #107 and resolves #94.

## Changes

- Fixes problem with new adventure log form not redirecting to game session show page upon success.
- Adds length validation to `content` field of adventure logs (minimum 1)
- Adds happy/sad path messaging to adventure log creation

## Screenshots

- Failure:
  <img width="605" alt="Screen Shot 2020-08-03 at 6 27 00 PM" src="https://user-images.githubusercontent.com/40702808/89239741-4b765880-d5b7-11ea-9788-712d8b7465e1.png">
- Success:
  <img width="1129" alt="Screen Shot 2020-08-03 at 6 29 10 PM" src="https://user-images.githubusercontent.com/40702808/89239752-54ffc080-d5b7-11ea-84f3-2678dde35539.png">

## State of tests

```
Finished in 6.05 seconds (files took 2.16 seconds to load)
118 examples, 0 failures

Coverage report generated for RSpec to /Users/dframpton/code/projects/cobalt_reserve/coverage. 1286 / 1286 LOC (100.0%) covered.
```

## GIF tax

![fist pump at end of breakfast club](https://media.giphy.com/media/OHZ1gSUThmEso/source.gif)