### PR TITLE
Happy/sad path messaging on new Game Session form

### DIFF
--- a/app/controllers/admin/game_sessions_controller.rb
+++ b/app/controllers/admin/game_sessions_controller.rb
@@ -6,21 +6,30 @@ class Admin::GameSessionsController < Admin::BaseController
   end
 
   def create
-    game_session = Campaign.current.game_sessions.create!(name: game_session_params[:name],
-                                                          date: Date.today)
-
-    game_session_params[:characters].each do |character_id|
-      GameSessionCharacter.create!(game_session_id: game_session.id,
-                                   character_id: character_id)
+    unless game_session_params[:characters]
+      flash[:error] = 'You must select at least one character.'
+      redirect_back fallback_location: admin_game_sessions_new_path and return
     end
-
-    redirect_to game_session_path(game_session)
+    
+    game_session = Campaign.current.game_sessions.new(name: game_session_params[:name],
+                                                      date: Date.today)
+    if game_session.save
+      game_session_params[:characters].each do |character_id|
+        GameSessionCharacter.create!(game_session_id: game_session.id,
+                                    character_id: character_id.to_i)
+      end
+      flash[:success] = 'Your game session was created.'
+      redirect_to game_session_path(game_session) and return
+    else
+      flash[:error] = game_session.errors.full_messages.join(', ')
+      redirect_back fallback_location: admin_game_sessions_new_path
+    end
   end
 
   private
 
   def game_session_params
     { name: params[:game_session][:name],
-      characters: params[:game_session][:characters].map(&:to_i) }
+      characters: params[:game_session][:characters] }
   end
 end

--- a/app/controllers/admin/game_sessions_controller.rb
+++ b/app/controllers/admin/game_sessions_controller.rb
@@ -10,13 +10,13 @@ class Admin::GameSessionsController < Admin::BaseController
       flash[:error] = 'You must select at least one character.'
       redirect_back fallback_location: admin_game_sessions_new_path and return
     end
-    
+
     game_session = Campaign.current.game_sessions.new(name: game_session_params[:name],
                                                       date: Date.today)
     if game_session.save
       game_session_params[:characters].each do |character_id|
         GameSessionCharacter.create!(game_session_id: game_session.id,
-                                    character_id: character_id.to_i)
+                                     character_id: character_id.to_i)
       end
       flash[:success] = 'Your game session was created.'
       redirect_to game_session_path(game_session) and return

--- a/app/models/game_session.rb
+++ b/app/models/game_session.rb
@@ -3,4 +3,6 @@ class GameSession < ApplicationRecord
   has_many :game_session_characters
   has_many :adventure_logs
   has_many :characters, through: :game_session_characters
+
+  validates_presence_of :name
 end

--- a/app/views/admin/game_sessions/new.html.erb
+++ b/app/views/admin/game_sessions/new.html.erb
@@ -1,9 +1,9 @@
 <h1>Create Session</h1>
 
-<%= form_with url: '/admin/game_sessions', model: @game_session do |form| %>
+<%= form_with url: '/admin/game_sessions', model: @game_session, local: true do |form| %>
   <p>
     <%= form.label :name %>
-    <%= form.text_field :name %>
+    <%= form.text_field :name, required: true %>
   </p>
 
   <h2>Select Characters</h2>

--- a/spec/features/admin/admin_can_create_a_game_session_with_attached_characters_spec.rb
+++ b/spec/features/admin/admin_can_create_a_game_session_with_attached_characters_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'admin dashboard index', type: :feature do
         @char3 = create(:character, campaign: campaign)
         @char4 = create(:inactive_character, campaign: campaign)
         user = create(:admin_user)
-    
+
         login_as_user(user.username, user.password)
       end
 

--- a/spec/features/admin/admin_can_create_a_game_session_with_attached_characters_spec.rb
+++ b/spec/features/admin/admin_can_create_a_game_session_with_attached_characters_spec.rb
@@ -3,53 +3,70 @@ require 'rails_helper'
 RSpec.describe 'admin dashboard index', type: :feature do
   context 'as an admin' do
     context 'I can click create session in the dashboard' do
-      it 'lets me create a session' do
+      before do
         campaign = create(:campaign)
-        char1 = create(:character, campaign: campaign)
-        char2 = create(:character, campaign: campaign)
-        char3 = create(:character, campaign: campaign)
-        char4 = create(:inactive_character, campaign: campaign)
+        @char1 = create(:character, campaign: campaign)
+        @char2 = create(:character, campaign: campaign)
+        @char3 = create(:character, campaign: campaign)
+        @char4 = create(:inactive_character, campaign: campaign)
         user = create(:admin_user)
-
+    
         login_as_user(user.username, user.password)
+      end
+
+      it 'lets me create a session' do
         visit admin_dashboard_path
 
         click_on 'Create Session'
 
         expect(current_path).to eq(admin_game_sessions_new_path)
-        expect(page).to have_content(char1.name)
-        expect(page).to have_content(char2.name)
-        expect(page).to have_content(char3.name)
-        expect(page).not_to have_content(char4.name)
+        expect(page).to have_content(@char1.name)
+        expect(page).to have_content(@char2.name)
+        expect(page).to have_content(@char3.name)
+        expect(page).not_to have_content(@char4.name)
 
         fill_in 'Name', with: 'Super Great Fun'
-        check char1.name
-        check char3.name
+        check @char1.name
+        check @char3.name
         click_on 'Create Game Session'
 
+        expect(page).to have_content 'Your game session was created.'
         expect(page).to have_content('Super Great Fun')
-        expect(page).to have_content(char1.name)
-        expect(page).to have_content(char3.name)
-        expect(page).to_not have_content(char2.name)
+        expect(page).to have_content(@char1.name)
+        expect(page).to have_content(@char3.name)
+        expect(page).to_not have_content(@char2.name)
         expect(page).to have_content(Date.today)
       end
 
       it 'does not let me add an inactive character to a session' do
-        campaign = create(:campaign)
-        char1 = create(:character, campaign: campaign)
-        char2 = create(:character, campaign: campaign)
-        char3 = create(:character, campaign: campaign)
-        char4 = create(:character, campaign: campaign, active: false)
-        user = create(:admin_user)
-
-        login_as_user(user.username, user.password)
         visit admin_dashboard_path
 
         click_on 'Create Session'
 
         expect(current_path).to eq(admin_game_sessions_new_path)
+        expect(page).to_not have_content(@char4.name)
+      end
 
-        expect(page).to_not have_content(char4.name)
+      it 'shows me an error message if no characters selected' do
+        visit admin_dashboard_path
+
+        click_on 'Create Session'
+        fill_in 'Name', with: 'There and Back Again'
+        click_on 'Create Game Session'
+
+        expect(current_path).to eq(admin_game_sessions_new_path)
+        expect(page).to have_content 'You must select at least one character.'
+      end
+
+      it 'does not allow me to submit if no name is entered' do
+        visit admin_dashboard_path
+
+        click_on 'Create Session'
+        check @char1.name
+        click_on 'Create Game Session'
+
+        expect(current_path).to eq(admin_game_sessions_new_path)
+        expect(page).to have_content "Name can't be blank"
       end
     end
   end

--- a/spec/models/game_session_spec.rb
+++ b/spec/models/game_session_spec.rb
@@ -7,4 +7,8 @@ RSpec.describe GameSession, type: :model do
     it { should have_many :adventure_logs }
     it { should have_many(:characters).through(:game_session_characters) }
   end
+
+  describe 'validations' do
+    it { should validate_presence_of :name }
+  end
 end


### PR DESCRIPTION
## Issues

Resolves #90.

## Changes

- Adds happy/sad path messaging to new Game Session form
- Adds validation of presence of name to game session model
- Fixes problem with broken redirect after successful game session creation

## Screenshots

- No name (HTML5 error, with backup flash message for older browsers):
  <img width="498" alt="Screen Shot 2020-08-03 at 7 41 51 PM" src="https://user-images.githubusercontent.com/40702808/89243545-79609a80-d5c1-11ea-9a59-e9114592bca9.png">
  
- No characters:
  <img width="498" alt="Screen Shot 2020-08-03 at 7 43 14 PM" src="https://user-images.githubusercontent.com/40702808/89243603-972dff80-d5c1-11ea-93e9-8ed8eef605f4.png">

- Success:
  <img width="615" alt="Screen Shot 2020-08-03 at 7 45 21 PM" src="https://user-images.githubusercontent.com/40702808/89243716-e3793f80-d5c1-11ea-9f5f-4181925878e0.png">

## State of tests

```
Finished in 6.26 seconds (files took 4.38 seconds to load)
121 examples, 0 failures

Coverage report generated for RSpec to /Users/dframpton/code/projects/cobalt_reserve/coverage. 1296 / 1296 LOC (100.0%) covered.
```

## GIF tax

![gandalf you shall not pass](https://media.giphy.com/media/5SAPlGAS1YnLN9jHua/giphy-downsized.gif)