### PR TITLE
Change User "Status" String to "Active" Boolean

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   Exclude:
-    - '/db/**/*'
+    - '/db/**/*.rb'
 
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,9 @@ Style/FrozenStringLiteralComment:
 Layout/TrailingEmptyLines:
   Enabled: false
 
+Layout/TrailingBlankLines:
+  Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   Exclude:
-    - '/db/**/*.rb'
+    - 'db/**/*.rb'
 
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/app/controllers/game_sessions_controller.rb
+++ b/app/controllers/game_sessions_controller.rb
@@ -1,4 +1,8 @@
 class GameSessionsController < ApplicationController
+  def index
+    @game_sessions = GameSession.all
+  end
+
   def show
     @game_session = GameSession.find(params[:id])
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,11 +19,11 @@ class SessionsController < ApplicationController
   end
 
   def passwordless_new
-    @users = User.select(:id, :username).where.not(status: 'inactive').order(:username)
+    @users = User.select(:id, :username).where.not(active: false).order(:username)
   end
 
   def passwordless_create
-    user = User.where(id: params['user-select']).where.not(status: 'inactive').first
+    user = User.where(id: params['user-select']).where.not(active: false).first
     if !user.nil?
       user.update!(login_uuid: SecureRandom.uuid, login_timestamp: DateTime.now)
       AuthenticationMailer.with(user: user).send_login_email.deliver_now

--- a/app/views/application/_game_session.html.erb
+++ b/app/views/application/_game_session.html.erb
@@ -1,0 +1,10 @@
+<div class="card">
+  <div class="card-body" id="game_session_-<%= game_session.id %>">
+    <h5 class="card-title">
+      <%= link_to game_session.name, game_session_path(game_session) %>
+    </h5>
+    <h6 class="card-subtitle mb-2 text-muted">
+      <p class="ancestry">Date: <%= game_session.date.strftime("%D") %></p>
+    </h6> 
+  </div>
+</div>

--- a/app/views/game_sessions/index.html.erb
+++ b/app/views/game_sessions/index.html.erb
@@ -1,0 +1,3 @@
+<h1>Game Sessions</h1>
+
+<%= render(partial: "game_session", collection: @game_sessions) || render(partial: "empty_list") %>

--- a/app/views/static_pages/show.html.erb
+++ b/app/views/static_pages/show.html.erb
@@ -7,4 +7,7 @@
   <li>
     <%= link_to 'Character Index', characters_path %>
   </li>
+  <li>
+    <%= link_to 'Game Session Index', game_sessions_path %>
+  </li>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   resources :monsters, only: %i[index show]
   resources :characters, only: %i[index show]
 
-  resources :game_sessions, only: [:show] do
+  resources :game_sessions, only: %i[index show] do
     resources :adventure_logs, only: %i[new create]
   end
 

--- a/db/migrate/20200804015429_change_user_status.rb
+++ b/db/migrate/20200804015429_change_user_status.rb
@@ -1,0 +1,6 @@
+class ChangeUserStatus < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :status, :string
+    add_column :users, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_02_024757) do
+ActiveRecord::Schema.define(version: 2020_08_04_015429) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -126,12 +126,12 @@ ActiveRecord::Schema.define(version: 2020_08_02_024757) do
     t.string "first_name"
     t.string "last_name"
     t.string "email"
-    t.string "status"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "login_uuid"
     t.datetime "login_timestamp"
     t.integer "role", default: 0
+    t.boolean "active", default: true
     t.index ["login_uuid"], name: "index_users_on_login_uuid"
   end
 

--- a/spec/features/game_sessions/anyone_can_see_game_session_index_spec.rb
+++ b/spec/features/game_sessions/anyone_can_see_game_session_index_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe "game session index", type: :feature do
+  before do
+    campaign = create(:campaign)
+    @game_session_1 = create(:game_session, campaign: campaign)
+    @game_session_2 = create(:game_session, campaign: campaign)
+    @game_session_3 = create(:game_session, campaign: campaign)
+  end
+
+  context 'as a visitor' do
+    it 'I see a link on the homepage which takes me to game session index' do
+      validate_game_session_index
+    end
+
+    it 'I can click the name of a game session to go to its show page' do
+      visit '/game_sessions'
+
+      click_on @game_session_1.name
+
+      expect(current_path).to eq game_session_path(@game_session_1)
+      expect(page).to have_content @game_session_1.name
+    end
+  end
+
+  context 'as a logged-in standard user' do
+    it 'I see a link on the homepage which takes me to game session index' do
+      validate_game_session_index
+    end
+  end
+
+  context 'as a logged-in admin user' do
+    it 'I see a link on the homepage which takes me to game session index' do
+      validate_game_session_index
+    end
+  end
+end
+
+def validate_game_session_index
+  visit '/'
+
+  click_link 'Game Session Index'
+
+  expect(current_path).to eq '/game_sessions'
+  expect(page).to have_link @game_session_1.name, href: game_session_path(@game_session_1)
+  expect(page).to have_link @game_session_2.name, href: game_session_path(@game_session_2)
+  expect(page).to have_link @game_session_3.name, href: game_session_path(@game_session_3)
+end

--- a/spec/features/game_sessions/anyone_can_see_game_session_index_spec.rb
+++ b/spec/features/game_sessions/anyone_can_see_game_session_index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "game session index", type: :feature do
+RSpec.describe 'game session index', type: :feature do
   before do
     campaign = create(:campaign)
     @game_session_1 = create(:game_session, campaign: campaign)
@@ -10,7 +10,11 @@ RSpec.describe "game session index", type: :feature do
 
   context 'as a visitor' do
     it 'I see a link on the homepage which takes me to game session index' do
-      validate_game_session_index
+      validate_game_session_link
+
+      expect(page).to have_link @game_session_1.name, href: game_session_path(@game_session_1)
+      expect(page).to have_link @game_session_2.name, href: game_session_path(@game_session_2)
+      expect(page).to have_link @game_session_3.name, href: game_session_path(@game_session_3)
     end
 
     it 'I can click the name of a game session to go to its show page' do
@@ -25,24 +29,21 @@ RSpec.describe "game session index", type: :feature do
 
   context 'as a logged-in standard user' do
     it 'I see a link on the homepage which takes me to game session index' do
-      validate_game_session_index
+      validate_game_session_link
     end
   end
 
   context 'as a logged-in admin user' do
     it 'I see a link on the homepage which takes me to game session index' do
-      validate_game_session_index
+      validate_game_session_link
     end
   end
 end
 
-def validate_game_session_index
+def validate_game_session_link
   visit '/'
 
   click_link 'Game Session Index'
 
   expect(current_path).to eq '/game_sessions'
-  expect(page).to have_link @game_session_1.name, href: game_session_path(@game_session_1)
-  expect(page).to have_link @game_session_2.name, href: game_session_path(@game_session_2)
-  expect(page).to have_link @game_session_3.name, href: game_session_path(@game_session_3)
 end

--- a/spec/features/users/user_log_in_spec.rb
+++ b/spec/features/users/user_log_in_spec.rb
@@ -8,13 +8,12 @@ RSpec.describe 'Logging In', type: :feature do
       username: 'funbucket13',
       password: 'test',
       email: 'bucket@example.com',
-      status: 'active'
     )
     @inactive_user = User.create(
       username: 'sadbucket42',
       password: 'test',
       email: 'sadbucket@example.com',
-      status: 'inactive'
+      active: false
     )
   end
 
@@ -142,7 +141,7 @@ RSpec.describe 'Logging In', type: :feature do
       end
 
       it 'fails if user is deactivated between trying to login and clicking the auth link' do
-        @user.update!(status: 'inactive')
+        @user.update!(active: false)
 
         visit passwordless_return_path(@fake_uuid)
 

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe AuthenticationMailer, type: :mailer do
       username: 'funbucket13',
       password: 'test',
       email: 'bucket@example.com',
-      status: 'active'
     )
 
     email = AuthenticationMailer.with(user: user).send_login_email


### PR DESCRIPTION
## Issues

Resolves #104 and #93.

## Changes

- Removed `status` field from User table
- Added `active` boolean field to User table with default value of `true`
- Updated tests and controllers to reflect database change
- Users now correctly appearing on "Passwordless Log In" page
- Created Game Session Index page linked to from homepage (unrelated...forgot I was still on this branch 🤦)

## Screenshots

- Can access again:
<img width="615" alt="Screen Shot 2020-08-03 at 8 26 43 PM" src="https://user-images.githubusercontent.com/40702808/89246149-b4fe6300-d5c7-11ea-8c08-dba1bb8108d9.png">

- Only active users on menu:
<img width="615" alt="Screen Shot 2020-08-03 at 8 28 12 PM" src="https://user-images.githubusercontent.com/40702808/89246258-f858d180-d5c7-11ea-95a4-036c9869c3f1.png">

- Users in database:
<img width="306" alt="Screen Shot 2020-08-03 at 8 28 46 PM" src="https://user-images.githubusercontent.com/40702808/89246263-fc84ef00-d5c7-11ea-876c-3e88e0bc96e5.png">

- Link to Game Session Index on homepage:

<img width="559" alt="Screen Shot 2020-08-03 at 9 11 42 PM" src="https://user-images.githubusercontent.com/40702808/89248872-027dce80-d5ce-11ea-9f4d-9d9e2891f0ae.png">

- Game Session Index:

<img width="526" alt="Screen Shot 2020-08-03 at 9 11 50 PM" src="https://user-images.githubusercontent.com/40702808/89248888-090c4600-d5ce-11ea-9db0-32971f2fbabf.png">

## State of tests

```
Finished in 6.03 seconds (files took 2.14 seconds to load)
125 examples, 0 failures

Coverage report generated for RSpec to /Users/dframpton/code/projects/cobalt_reserve/coverage. 1326 / 1326 LOC (100.0%) covered.
```

## GIF tax

![amazon drone](https://media.giphy.com/media/lkMZJBR2roOIw/source.gif)