### PR TITLE
A user can edit the backstory of their characters

### DIFF
--- a/app/controllers/backstory_controller.rb
+++ b/app/controllers/backstory_controller.rb
@@ -1,5 +1,7 @@
 class BackstoryController < ApplicationController
+
   def edit
+    redirect_to root_path unless current_user
     @character = Character.find(params[:id])
   end
 
@@ -11,15 +13,15 @@ class BackstoryController < ApplicationController
 
   private
 
-    def character_params
-      params.require(:character)
-            .permit(:age,
-                    :early_life,
-                    :moral_code,
-                    :personality,
-                    :fears,
-                    :role,
-                    :additional_information)
-    end
+  def character_params
+    params.require(:character)
+          .permit(:age,
+                  :early_life,
+                  :moral_code,
+                  :personality,
+                  :fears,
+                  :role,
+                  :additional_information)
+  end
 
 end

--- a/app/controllers/backstory_controller.rb
+++ b/app/controllers/backstory_controller.rb
@@ -1,0 +1,25 @@
+class BackstoryController < ApplicationController
+  def edit
+    @character = Character.find(params[:id])
+  end
+
+  def update
+    character = Character.find(params[:id])
+    character.update(character_params)
+    redirect_to character_path(character)
+  end
+
+  private
+
+    def character_params
+      params.require(:character)
+            .permit(:age,
+                    :early_life,
+                    :moral_code,
+                    :personality,
+                    :fears,
+                    :role,
+                    :additional_information)
+    end
+
+end

--- a/app/controllers/backstory_controller.rb
+++ b/app/controllers/backstory_controller.rb
@@ -1,5 +1,4 @@
 class BackstoryController < ApplicationController
-
   def edit
     redirect_to root_path unless current_user
     @character = Character.find(params[:id])
@@ -23,5 +22,4 @@ class BackstoryController < ApplicationController
                   :role,
                   :additional_information)
   end
-
 end

--- a/app/views/application/_character.html.erb
+++ b/app/views/application/_character.html.erb
@@ -12,6 +12,7 @@
     <p>Active: <%= character.active %></p>
     <% if current_user == character.user %>
       <p><%= button_to 'Edit Character', edit_user_character_path(character.user, character.id), method: 'get', class: 'card-link' %></p>
+      <p><%= button_to 'Edit Backstory', backstory_edit_path(character), method: 'get' %></p>
       <% unless character.active %>
       <p><%= button_to 'Make Active!', user_activate_character_path(character.user, character.id), method: 'put', class: 'card-link' %></p>
       <% end %>

--- a/app/views/backstory/edit.html.erb
+++ b/app/views/backstory/edit.html.erb
@@ -1,0 +1,22 @@
+<h1>Edit Backstory</h1>
+
+<%= form_with model: @character, url: backstory_update_path(@character) do |form| %>
+  <p><%= form.label :age, "Age (In Years):" %><br>
+  <%= form.text_field :age %></p>
+  <p><%= form.label :early_life, "Where was your character born? Where were you raised? By who? Your character’s actions and influence may be a product of their childhood. Is your character local? Do these places bring back memories? Or, is the path they walk not from these parts?" %><br>
+  <%= form.text_area :early_life %></p>
+  <p><%= form.label :moral_code, "What is your character’s moral code? Are they a natural do-gooder? Or, does their sense of warped morality come from a sordid background? A character’s alignment will heavily influence their actions, be sure to outline why they arrived at their moral code." %><br>
+  <%= form.text_area :moral_code %></p>
+  <p><%= form.label :personality, "Does your character have any personality quirks? Do you get hiccups every time something surprises you? Or, do you have compulsively share ‘fun facts’ about everything, that are usually wrong? Personality quirks brings a character to life." %><br>
+  <%= form.text_area :personality %></p>
+  <p><%= form.label :fears, "Is there anything that your character fears? Hero, champion or winner. We all have fears! Knowing your character’s fears will influence how they navigate through their quests." %><br>
+  <%= form.text_area :fears%></p>
+  <p><%= form.label :role, "How does your character view their role as an adventurer? A means to an end or something they does proudly?Thinking about how your character functions in a group is an important aspect of role-playing." %><br>
+  <%= form.text_area :role %></p>
+  <p><%= form.label :additional_information, "How does your character view their role as an adventurer? A means to an end or something they does proudly?Thinking about how your character functions in a group is an important aspect of role-playing." %><br>
+  <%= form.text_area :additional_information %></p>
+  <br>
+
+
+  <%= submit_tag "Update Backstory" %>
+<% end %>

--- a/app/views/characters/show.html.erb
+++ b/app/views/characters/show.html.erb
@@ -1,1 +1,25 @@
 <%= render partial: "character", locals: { character: @character } %>
+
+<h2>Backstory</h2>
+
+<p>Age: <%= @character.age %> </p>
+
+<p>Early Life:<p>
+<p><%= @character.early_life %></p>
+
+
+<p>Moral Code:<p>
+<p><%= @character.moral_code %></p>
+
+<p>Personality: <p>
+<p><%= @character.personality %></p>
+
+<p>Fears:<p>
+<p><%= @character.fears %></p>
+
+<p>Role:<p>
+<p><%= @character.role %></p>
+
+<p>Additional Information:<p>
+<p><%= @character.additional_information %></p>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,5 +30,4 @@ Rails.application.routes.draw do
     resources :characters, only: %i[new create edit update]
     put '/character/:id/activate', to: 'characters#activate', as: :activate_character
   end
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,9 @@ Rails.application.routes.draw do
   resources :monsters, only: %i[index show]
   resources :characters, only: %i[index show]
 
+  get '/characters/:id/backstory/edit', to: 'backstory#edit', as: :backstory_edit
+  patch '/characters/:id/backstory', to: 'backstory#update', as: :backstory_update
+
   resources :game_sessions, only: %i[index show] do
     resources :adventure_logs, only: %i[new create]
   end
@@ -27,4 +30,5 @@ Rails.application.routes.draw do
     resources :characters, only: %i[new create edit update]
     put '/character/:id/activate', to: 'characters#activate', as: :activate_character
   end
+
 end

--- a/db/migrate/20200805015715_add_backstory_to_characters.rb
+++ b/db/migrate/20200805015715_add_backstory_to_characters.rb
@@ -1,0 +1,11 @@
+class AddBackstoryToCharacters < ActiveRecord::Migration[6.0]
+  def change
+    add_column :characters, :age, :string
+    add_column :characters, :early_life, :text
+    add_column :characters, :moral_code, :text
+    add_column :characters, :personality, :text
+    add_column :characters, :fears, :text
+    add_column :characters, :role, :text
+    add_column :characters, :additional_information, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_04_015429) do
+ActiveRecord::Schema.define(version: 2020_08_05_015715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,13 @@ ActiveRecord::Schema.define(version: 2020_08_04_015429) do
     t.bigint "ancestryone_id", null: false
     t.bigint "ancestrytwo_id"
     t.bigint "culture_id", null: false
+    t.string "age"
+    t.text "early_life"
+    t.text "moral_code"
+    t.text "personality"
+    t.text "fears"
+    t.text "role"
+    t.text "additional_information"
     t.index ["ancestryone_id"], name: "index_characters_on_ancestryone_id"
     t.index ["ancestrytwo_id"], name: "index_characters_on_ancestrytwo_id"
     t.index ["campaign_id"], name: "index_characters_on_campaign_id"

--- a/spec/features/characters/user_can_edit_a_backstory_for_their_character_spec.rb
+++ b/spec/features/characters/user_can_edit_a_backstory_for_their_character_spec.rb
@@ -1,58 +1,71 @@
 require 'rails_helper'
 
 RSpec.describe 'Character Backstory', type: :feature do
-  it 'can create a backstory for their character' do
-    campaign = create(:campaign, status: 'active')
-    user = create(:user)
-    character = create(:character, user: user, campaign: campaign, active: true)
+  context 'as a default user' do
+    it 'can create a backstory for their character' do
+      campaign = create(:campaign, status: 'active')
+      user = create(:user)
+      character = create(:character, user: user, campaign: campaign, active: true)
 
-    login_as_user(user.username, user.password)
-    visit character_path(character)
-    click_on 'Edit Backstory'
+      login_as_user(user.username, user.password)
+      visit character_path(character)
+      click_on 'Edit Backstory'
 
-    expect(current_path).to eq(backstory_edit_path(character))
+      expect(current_path).to eq(backstory_edit_path(character))
 
-    expect(page).to_not have_content('20 years')
-    expect(page).to_not have_content('it sucked')
-    expect(page).to_not have_content('Chaotic Salsa')
-    expect(page).to_not have_content('meh')
-    expect(page).to_not have_content('spiders')
-    expect(page).to_not have_content('front')
-    expect(page).to_not have_content('more')
+      expect(page).to_not have_content('20 years')
+      expect(page).to_not have_content('it sucked')
+      expect(page).to_not have_content('Chaotic Salsa')
+      expect(page).to_not have_content('meh')
+      expect(page).to_not have_content('spiders')
+      expect(page).to_not have_content('front')
+      expect(page).to_not have_content('more')
 
-    fill_in :character_age, with: '20 years'
-    fill_in :character_early_life, with: 'it sucked'
-    fill_in :character_moral_code, with: 'Chaotic Salsa'
-    fill_in :character_personality, with: 'meh'
-    fill_in :character_fears, with: 'spiders'
-    fill_in :character_role, with: 'front'
-    fill_in :character_additional_information, with: 'more'
+      fill_in :character_age, with: '20 years'
+      fill_in :character_early_life, with: 'it sucked'
+      fill_in :character_moral_code, with: 'Chaotic Salsa'
+      fill_in :character_personality, with: 'meh'
+      fill_in :character_fears, with: 'spiders'
+      fill_in :character_role, with: 'front'
+      fill_in :character_additional_information, with: 'more'
 
-    click_on 'Update Backstory'
+      click_on 'Update Backstory'
 
-    expect(current_path).to eq(character_path(character))
+      expect(current_path).to eq(character_path(character))
 
-    expect(page).to have_content('20 years')
-    expect(page).to have_content('it sucked')
-    expect(page).to have_content('Chaotic Salsa')
-    expect(page).to have_content('meh')
-    expect(page).to have_content('spiders')
-    expect(page).to have_content('front')
-    expect(page).to have_content('more')
+      expect(page).to have_content('20 years')
+      expect(page).to have_content('it sucked')
+      expect(page).to have_content('Chaotic Salsa')
+      expect(page).to have_content('meh')
+      expect(page).to have_content('spiders')
+      expect(page).to have_content('front')
+      expect(page).to have_content('more')
+    end
+
+    it 'cannot create a backstory for a character that it does not own' do
+      campaign = create(:campaign, status: 'active')
+      user = create(:user)
+      character = create(:character, user: user, campaign: campaign, active: true)
+      user_2 = create(:user)
+      character_2 = create(:character, user: user_2, campaign: campaign, active: true)
+
+      login_as_user(user_2.username, user_2.password)
+
+      visit character_path(character)
+
+      expect(page).to_not have_selector(:link_or_button, 'Edit Backstory')
+    end
   end
 
-  it 'cannot create a backstory for a character that it does not own' do
-    campaign = create(:campaign, status: 'active')
-    user = create(:user)
-    character = create(:character, user: user, campaign: campaign, active: true)
-    user_2 = create(:user)
-    character_2 = create(:character, user: user_2, campaign: campaign, active: true)
+  context 'as a visitor' do
+    it 'a visitor cannot edit a characters backstory' do
+      campaign = create(:campaign, status: 'active')
+      user = create(:user)
+      character = create(:character, user: user, campaign: campaign, active: true)
 
-    login_as_user(user_2.username, user_2.password)
+      visit character_path(character)
 
-    visit character_path(character)
-
-    expect(page).to_not have_selector(:link_or_button, 'Edit Backstory')
-
+      expect(page).to_not have_selector(:link_or_button, 'Edit Backstory')
+    end
   end
 end

--- a/spec/features/characters/user_can_edit_a_backstory_for_their_character_spec.rb
+++ b/spec/features/characters/user_can_edit_a_backstory_for_their_character_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe 'Character Backstory', type: :feature do
     expect(page).to have_content('spiders')
     expect(page).to have_content('front')
     expect(page).to have_content('more')
+  end
+
+  it 'cannot create a backstory for a character that it is not logged in as' do
+    campaign = create(:campaign, status: 'active')
+    user = create(:user)
+    character = create(:character, user: user, campaign: campaign, active: true)
+    user_2 = create(:user)
+    character_2 = create(:character, user: user_2, campaign: campaign, active: true)
+
+    login_as_user(user_2.username, user_2.password)
+
+    expect(page).to_not have_selector(:link_or_button, 'Edit Backstory')
 
   end
 end

--- a/spec/features/characters/user_can_edit_a_backstory_for_their_character_spec.rb
+++ b/spec/features/characters/user_can_edit_a_backstory_for_their_character_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'Character Backstory', type: :feature do
+  it 'can create a backstory for their character' do
+    campaign = create(:campaign, status: 'active')
+    user = create(:user)
+    character = create(:character, user: user, campaign: campaign, active: true)
+
+    login_as_user(user.username, user.password)
+    visit character_path(character)
+    click_on 'Edit Backstory'
+
+    expect(current_path).to eq(backstory_edit_path(character))
+
+    expect(page).to_not have_content('20 years')
+    expect(page).to_not have_content('it sucked')
+    expect(page).to_not have_content('Chaotic Salsa')
+    expect(page).to_not have_content('meh')
+    expect(page).to_not have_content('spiders')
+    expect(page).to_not have_content('front')
+    expect(page).to_not have_content('more')
+
+    fill_in :character_age, with: '20 years'
+    fill_in :character_early_life, with: 'it sucked'
+    fill_in :character_moral_code, with: 'Chaotic Salsa'
+    fill_in :character_personality, with: 'meh'
+    fill_in :character_fears, with: 'spiders'
+    fill_in :character_role, with: 'front'
+    fill_in :character_additional_information, with: 'more'
+
+    click_on 'Update Backstory'
+
+    expect(current_path).to eq(character_path(character))
+
+    expect(page).to have_content('20 years')
+    expect(page).to have_content('it sucked')
+    expect(page).to have_content('Chaotic Salsa')
+    expect(page).to have_content('meh')
+    expect(page).to have_content('spiders')
+    expect(page).to have_content('front')
+    expect(page).to have_content('more')
+
+  end
+end

--- a/spec/features/characters/user_can_edit_a_backstory_for_their_character_spec.rb
+++ b/spec/features/characters/user_can_edit_a_backstory_for_their_character_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Character Backstory', type: :feature do
     expect(page).to have_content('more')
   end
 
-  it 'cannot create a backstory for a character that it is not logged in as' do
+  it 'cannot create a backstory for a character that it does not own' do
     campaign = create(:campaign, status: 'active')
     user = create(:user)
     character = create(:character, user: user, campaign: campaign, active: true)
@@ -49,6 +49,8 @@ RSpec.describe 'Character Backstory', type: :feature do
     character_2 = create(:character, user: user_2, campaign: campaign, active: true)
 
     login_as_user(user_2.username, user_2.password)
+
+    visit character_path(character)
 
     expect(page).to_not have_selector(:link_or_button, 'Edit Backstory')
 

--- a/spec/features/characters/user_can_edit_a_backstory_for_their_character_spec.rb
+++ b/spec/features/characters/user_can_edit_a_backstory_for_their_character_spec.rb
@@ -67,5 +67,15 @@ RSpec.describe 'Character Backstory', type: :feature do
 
       expect(page).to_not have_selector(:link_or_button, 'Edit Backstory')
     end
+
+    it 'cannot access a backstory edit page' do
+      campaign = create(:campaign, status: 'active')
+      user = create(:user)
+      character = create(:character, user: user, campaign: campaign, active: true)
+
+      visit backstory_edit_path(character)
+
+      expect(current_path).to eq(root_path)
+    end
   end
 end


### PR DESCRIPTION
Added functionality and testing. Includes testing to ensure that a user can only edit backstories for the characters they own and that visitors cannot edit backstories.