### PR TITLE
adds foundry key visibility closes #106

### DIFF
--- a/app/views/characters/_form.html.erb
+++ b/app/views/characters/_form.html.erb
@@ -1,3 +1,4 @@
+
 <%= form_for [@user, @character], url: @form_submission_url do |f| %>
   <% if @character.errors.any? %>
     <div id="error_explanation">

--- a/app/views/characters/show.html.erb
+++ b/app/views/characters/show.html.erb
@@ -1,5 +1,9 @@
 <%= render partial: "character", locals: { character: @character } %>
 
+<% if current_user == @character.user || current_admin? %>
+  <p><b>Foundry Key:</b> <%= @character.foundry_key %></p>
+<% end %>
+
 <h2>Backstory</h2>
 
 <p>Age: <%= @character.age %> </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
 
   get '/characters/:id/backstory/edit', to: 'backstory#edit', as: :backstory_edit
   patch '/characters/:id/backstory', to: 'backstory#update', as: :backstory_update
+  patch '/characters/:id/foundry_key', to: 'foundry_key#update', as: :foundry_key_update
 
   resources :game_sessions, only: %i[index show] do
     resources :adventure_logs, only: %i[new create]

--- a/db/migrate/20200805033434_add_key_to_characters.rb
+++ b/db/migrate/20200805033434_add_key_to_characters.rb
@@ -1,0 +1,5 @@
+class AddKeyToCharacters < ActiveRecord::Migration[6.0]
+  def change
+    add_column :characters, :foundry_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_05_015715) do
+ActiveRecord::Schema.define(version: 2020_08_05_033434) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2020_08_05_015715) do
     t.text "fears"
     t.text "role"
     t.text "additional_information"
+    t.string "foundry_key"
     t.index ["ancestryone_id"], name: "index_characters_on_ancestryone_id"
     t.index ["ancestrytwo_id"], name: "index_characters_on_ancestrytwo_id"
     t.index ["campaign_id"], name: "index_characters_on_campaign_id"

--- a/spec/factories/character_factory.rb
+++ b/spec/factories/character_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     level { Faker::Number.between(from: 1, to: 20).to_i }
     dndbeyond_url { "https://dndbeyond/#{Faker::Number.within(range: 100000..999999)}"}
     active { true }
+    foundry_key { Faker::JapaneseMedia::SwordArtOnline.game_name }
 
     ancestryone
     ancestrytwo

--- a/spec/features/characters/foundry_keys/user_can_see_foundry_key_for_their_character_spec.rb
+++ b/spec/features/characters/foundry_keys/user_can_see_foundry_key_for_their_character_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'Foundry Key', type: :feature do
+  context 'as a user' do
+    it 'can display a characters foundry key on their show page' do
+      campaign = create(:campaign)
+      user = create(:user)
+      character = create(:character, campaign: campaign, user: user)
+
+      login_as_user(user.username, user.password)
+
+      visit character_path(character)
+
+      expect(page).to have_content(character.foundry_key)
+    end
+
+    it 'cannot display another characters foundry_key' do
+      campaign = create(:campaign)
+      user = create(:user)
+      character = create(:character, campaign: campaign, user: user)
+      user_2 = create(:user)
+
+      login_as_user(user_2.username, user_2.password)
+      visit character_path(character)
+
+      expect(page).to_not have_content(character.foundry_key)
+    end
+  end
+
+  context 'as an admin user' do
+    it 'can display a characters foundry key on their show page' do
+      campaign = create(:campaign)
+      admin = create(:admin_user)
+      user = create(:user)
+      character = create(:character, campaign: campaign, user: user)
+
+      login_as_user(admin.username, admin.password)
+      visit character_path(character)
+
+      expect(page).to have_content(character.foundry_key)
+    end
+  end
+
+  context 'as a visitor' do
+    it 'cannot see a characters foundry key on their show page' do
+      campaign = create(:campaign)
+      user = create(:user)
+      character = create(:character, campaign: campaign, user: user)
+
+      visit character_path(character)
+
+      expect(page).to_not have_content(character.foundry_key)
+    end
+  end
+end


### PR DESCRIPTION
Characters now have a foundry_key. It is visible on the character show page for admins and the appropriate users.