### PR TITLE
Campaign management

### DIFF
--- a/app/controllers/admin/campaign_status_controller.rb
+++ b/app/controllers/admin/campaign_status_controller.rb
@@ -1,0 +1,9 @@
+class Admin::CampaignStatusController < Admin::BaseController
+  def update
+    current_campaign.update(status: 'inactive')
+    new_current = Campaign.find(params[:id])
+    new_current.update(status: 'active')
+    @current_campaign = new_current
+    redirect_to admin_campaigns_path
+  end
+end

--- a/app/controllers/admin/campaigns_controller.rb
+++ b/app/controllers/admin/campaigns_controller.rb
@@ -1,0 +1,38 @@
+class Admin::CampaignsController < Admin::BaseController
+  def index
+    @campaigns = Campaign.all
+  end
+
+  def show
+    @campaign = Campaign.find(params[:id])
+  end
+
+  def edit
+    @campaign = Campaign.find(params[:id])
+  end
+
+  def update
+    campaign = Campaign.find(params[:id])
+    campaign.update(campaign_params)
+    redirect_to admin_campaign_path(campaign)
+  end
+
+  def new
+    @campaign = Campaign.new
+  end
+
+  def create
+    Campaign.create(campaign_params)
+    redirect_to admin_campaigns_path
+  end
+
+  def destroy
+    Campaign.find(params[:id]).destroy
+    redirect_to admin_campaigns_path
+  end
+
+  private
+    def campaign_params
+      params.require(:campaign).permit(:name)
+    end
+end

--- a/app/controllers/admin/campaigns_controller.rb
+++ b/app/controllers/admin/campaigns_controller.rb
@@ -32,6 +32,7 @@ class Admin::CampaignsController < Admin::BaseController
   end
 
   private
+
     def campaign_params
       params.require(:campaign).permit(:name)
     end

--- a/app/views/admin/campaigns/edit.html.erb
+++ b/app/views/admin/campaigns/edit.html.erb
@@ -1,0 +1,5 @@
+<%= form_with model: @campaign, url: admin_campaign_path(@campaign), local: true do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+  <%= form.submit 'Update Campaign' %>
+<% end %>

--- a/app/views/admin/campaigns/index.html.erb
+++ b/app/views/admin/campaigns/index.html.erb
@@ -1,0 +1,12 @@
+<h1>Campaign Managment</h1>
+
+<h2>Campaigns</h2>
+
+<% @campaigns.each do |campaign| %>
+  <p id="campaign-<%= campaign.id %>">
+  <%= link_to campaign.name, admin_campaign_path(campaign) %> -
+  <%= link_to 'Edit', edit_admin_campaign_path(campaign) %>
+  </p>
+<% end %>
+
+<p><%= link_to 'Create New Campaign', new_admin_campaign_path %></p>

--- a/app/views/admin/campaigns/index.html.erb
+++ b/app/views/admin/campaigns/index.html.erb
@@ -5,7 +5,10 @@
 <% @campaigns.each do |campaign| %>
   <p id="campaign-<%= campaign.id %>">
   <%= link_to campaign.name, admin_campaign_path(campaign) %> -
-  <%= link_to 'Edit', edit_admin_campaign_path(campaign) %>
+  <%= link_to 'Edit', edit_admin_campaign_path(campaign) %> -
+  <% unless current_campaign == campaign %>
+    <%= link_to 'Make Active', "/admin/campaigns/#{campaign.id}/status", method: :patch %>
+  <% end %>
   </p>
 <% end %>
 

--- a/app/views/admin/campaigns/new.html.erb
+++ b/app/views/admin/campaigns/new.html.erb
@@ -1,0 +1,7 @@
+<h1>New Campaign</h1>
+
+<%= form_with model: @campaign, url: admin_campaigns_path, local: true do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+  <%= form.submit 'Create Campaign' %>
+<% end %>

--- a/app/views/admin/campaigns/show.html.erb
+++ b/app/views/admin/campaigns/show.html.erb
@@ -1,0 +1,3 @@
+<h1><%= @campaign.name %></h1>
+
+<%= link_to 'Delete Campaign', admin_campaign_path(@campaign), method: :delete %>

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -10,3 +10,5 @@
 
 <p><%= link_to 'Add New World Map', admin_world_maps_new_path %></p>
 
+<p><%= link_to 'Campaign Management', admin_campaigns_path %></p>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     get '/foundry_key/:id/edit', to: 'foundry_key#edit', as: :edit_foundry_key
     patch '/foundry_key/:id', to: 'foundry_key#update', as: :update_foundry_key
     resources :world_news
+    resources :campaigns
   end
 
   get '/passwordless-login', to: 'sessions#passwordless_new', as: :passwordless_login

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,6 @@ Rails.application.routes.draw do
     resources :campaigns
   end
 
-
-
   get '/passwordless-login', to: 'sessions#passwordless_new', as: :passwordless_login
   post '/passwordless-login', to: 'sessions#passwordless_create', as: :passwordless_login_post
   get '/auth/:login_uuid', to: 'sessions#passwordless_return', as: :passwordless_return

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,12 @@ Rails.application.routes.draw do
     get '/foundry_key', to: 'foundry_key#index'
     get '/foundry_key/:id/edit', to: 'foundry_key#edit', as: :edit_foundry_key
     patch '/foundry_key/:id', to: 'foundry_key#update', as: :update_foundry_key
+    patch '/campaigns/:id/status', to: 'campaign_status#update'
     resources :world_news
     resources :campaigns
   end
+
+
 
   get '/passwordless-login', to: 'sessions#passwordless_new', as: :passwordless_login
   post '/passwordless-login', to: 'sessions#passwordless_create', as: :passwordless_login_post

--- a/spec/features/admin/admin_campaign_management_spec.rb
+++ b/spec/features/admin/admin_campaign_management_spec.rb
@@ -127,4 +127,24 @@ RSpec.describe 'Admin Campaign Management', type: :feature do
       end
     end
   end
+
+  context 'as a visitor' do
+    it 'cannot access campaign management' do
+      visit admin_campaigns_path
+
+      expect(current_path).to eq(root_path)
+    end
+  end
+
+  context 'as a default user' do
+    it 'cannot access campaign management' do
+      user = create(:user)
+
+      login_as_user(user.username, user.password)
+
+      visit admin_campaigns_path
+
+      expect(current_path).to eq(root_path)
+    end
+  end
 end

--- a/spec/features/admin/admin_campaign_management_spec.rb
+++ b/spec/features/admin/admin_campaign_management_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin Campaign Management', type: :feature do
+  context 'as an admin user' do
+    it 'can get to the campaign management page from the dashboard' do
+      campaign = create(:campaign)
+      inactive_campaign = create(:inactive_campaign)
+      admin = create(:admin_user)
+
+      login_as_user(admin.username, admin.password)
+
+      visit admin_dashboard_path
+
+      click_on 'Campaign Management'
+
+      expect(current_path).to eq(admin_campaigns_path)
+      expect(page).to have_content(campaign.name)
+      expect(page).to have_content(inactive_campaign.name)
+    end
+
+    it 'can access a campaign show page' do
+      campaign = create(:campaign)
+      inactive_campaign = create(:inactive_campaign)
+      admin = create(:admin_user)
+
+      login_as_user(admin.username, admin.password)
+
+      visit admin_campaigns_path
+
+      within("#campaign-#{campaign.id}") do
+        click_on campaign.name
+      end
+
+      expect(current_path).to eq(admin_campaign_path(campaign))
+      expect(page).to have_content(campaign.name)
+      expect(page).to_not have_content(inactive_campaign.name)
+    end
+
+    it 'can edit a campaign name' do
+      campaign = create(:campaign)
+      admin = create(:admin_user)
+      old_name = campaign.name
+
+      login_as_user(admin.username, admin.password)
+
+      visit admin_campaigns_path
+
+      within("#campaign-#{campaign.id}") do
+        click_on 'Edit'
+      end
+
+      expect(current_path).to eq(edit_admin_campaign_path(campaign))
+      fill_in :campaign_name, with: 'new name'
+
+      click_on 'Update Campaign'
+
+      expect(current_path).to eq(admin_campaign_path(campaign))
+      expect(page).to have_content('new name')
+      expect(page).to_not have_content(old_name)
+    end
+
+    it 'can create a campaign' do
+      admin = create(:admin_user)
+
+      login_as_user(admin.username, admin.password)
+
+      visit admin_campaigns_path
+
+      click_on 'Create New Campaign'
+
+      expect(current_path).to eq(new_admin_campaign_path)
+
+      fill_in :campaign_name, with: 'This Old Campaign'
+
+      click_on 'Create Campaign'
+
+      expect(current_path).to eq(admin_campaigns_path)
+      expect(page).to have_content('This Old Campaign')
+    end
+
+    it 'can destroy a campaign' do
+      campaign = create(:campaign)
+      inactive_campaign = create(:inactive_campaign)
+      admin = create(:admin_user)
+      name = campaign.name
+
+      login_as_user(admin.username, admin.password)
+
+      visit admin_campaigns_path
+
+      expect(page).to have_content(campaign.name)
+      expect(page).to have_content(inactive_campaign.name)
+
+      click_on campaign.name
+      click_on 'Delete Campaign'
+
+      expect(current_path).to eq(admin_campaigns_path)
+      expect(page).to have_content(inactive_campaign.name)
+      expect(page).to_not have_content(name)
+    end
+  end
+end

--- a/spec/features/admin/admin_campaign_management_spec.rb
+++ b/spec/features/admin/admin_campaign_management_spec.rb
@@ -98,5 +98,33 @@ RSpec.describe 'Admin Campaign Management', type: :feature do
       expect(page).to have_content(inactive_campaign.name)
       expect(page).to_not have_content(name)
     end
+
+    it 'can make a campaign as active, making the previous campaign inactive' do
+      campaign = create(:campaign)
+      inactive_campaign = create(:inactive_campaign)
+      admin = create(:admin_user)
+
+      login_as_user(admin.username, admin.password)
+
+      visit admin_campaigns_path
+
+      within("#campaign-#{campaign.id}") do
+        expect(page).to_not have_link('Make Active')
+      end
+
+      within("#campaign-#{inactive_campaign.id}") do
+        click_on 'Make Active'
+      end
+
+      expect(current_path).to eq(admin_campaigns_path)
+
+      within("#campaign-#{campaign.id}") do
+        expect(page).to have_link('Make Active')
+      end
+
+      within("#campaign-#{inactive_campaign.id}") do
+        expect(page).to_not have_link('Make Active')
+      end
+    end
   end
 end

--- a/spec/features/admin/admin_can_create_a_game_session_with_attached_characters_spec.rb
+++ b/spec/features/admin/admin_can_create_a_game_session_with_attached_characters_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'admin dashboard index', type: :feature do
       it 'lets me create a session' do
         visit admin_dashboard_path
 
-        click_on 'Create Session'
+        click_on 'Create Game Session'
 
         expect(current_path).to eq(admin_game_sessions_new_path)
         expect(page).to have_content(@char1.name)
@@ -41,7 +41,7 @@ RSpec.describe 'admin dashboard index', type: :feature do
       it 'does not let me add an inactive character to a session' do
         visit admin_dashboard_path
 
-        click_on 'Create Session'
+        click_on 'Create Game Session'
 
         expect(current_path).to eq(admin_game_sessions_new_path)
         expect(page).to_not have_content(@char4.name)
@@ -50,7 +50,7 @@ RSpec.describe 'admin dashboard index', type: :feature do
       it 'shows me an error message if no characters selected' do
         visit admin_dashboard_path
 
-        click_on 'Create Session'
+        click_on 'Create Game Session'
         fill_in 'Name', with: 'There and Back Again'
         click_on 'Create Game Session'
 
@@ -61,7 +61,7 @@ RSpec.describe 'admin dashboard index', type: :feature do
       it 'does not allow me to submit if no name is entered' do
         visit admin_dashboard_path
 
-        click_on 'Create Session'
+        click_on 'Create Game Session'
         check @char1.name
         click_on 'Create Game Session'
 


### PR DESCRIPTION
Closes #82 

Adds admin CRUD functionality for campaigns. Adds tests for ensuring only admins can make changes to campaigns.