### PR TITLE
adds display of deceased characters

### DIFF
--- a/app/controllers/heroes_controller.rb
+++ b/app/controllers/heroes_controller.rb
@@ -1,0 +1,5 @@
+class HeroesController < ApplicationController
+  def index
+    @heroes = current_campaign.heroes if current_campaign
+  end
+end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -15,4 +15,8 @@ class Campaign < ApplicationRecord
   def latest_high_res
     world_maps.latest_map.high_res
   end
+
+  def heroes
+    characters.dead
+  end
 end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -19,6 +19,9 @@ class Character < ApplicationRecord
   validates :klass, presence: true
 
   scope :active, -> { where active: true }
+  scope :dead, -> { where status: 2 }
+
+  enum status: %w[alive dead]
 
   def build_ancestry
     ancestries = [ancestryone.name]

--- a/app/views/heroes/index.html.erb
+++ b/app/views/heroes/index.html.erb
@@ -1,0 +1,12 @@
+<center>
+  <h1>Hall of Heroes</h1>
+
+  <section id='dead-heroes'>
+    <% if current_campaign %>
+      <% @heroes.each do |hero| %>
+        <p><%= hero.name %></p>
+      <% end %>
+    <% end %>
+  </section>
+</center>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,4 +41,6 @@ Rails.application.routes.draw do
 
   resources :world_news, only: %i[index show]
   resources :world_maps, only: %i[index]
+
+  get '/hall-of-heroes', to: 'heroes#index'
 end

--- a/db/migrate/20200816194007_add_status_to_characters.rb
+++ b/db/migrate/20200816194007_add_status_to_characters.rb
@@ -1,0 +1,5 @@
+class AddStatusToCharacters < ActiveRecord::Migration[6.0]
+  def change
+    add_column :characters, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_09_053400) do
+ActiveRecord::Schema.define(version: 2020_08_16_194007) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 2020_08_09_053400) do
     t.text "role"
     t.text "additional_information"
     t.string "foundry_key"
+    t.integer "status", default: 0
     t.index ["ancestryone_id"], name: "index_characters_on_ancestryone_id"
     t.index ["ancestrytwo_id"], name: "index_characters_on_ancestrytwo_id"
     t.index ["campaign_id"], name: "index_characters_on_campaign_id"

--- a/spec/factories/character_factory.rb
+++ b/spec/factories/character_factory.rb
@@ -16,6 +16,11 @@ FactoryBot.define do
     user
   end
 
+  factory :dead_character, parent: :character do
+    active { false }
+    status { 1 }
+  end
+
   factory :inactive_character, parent: :character do
     active { false }
   end

--- a/spec/features/hall_of_heroes/hall_of_heroes_index_spec.rb
+++ b/spec/features/hall_of_heroes/hall_of_heroes_index_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'Hall of Heroes Index Page', type: :feature do
+  context 'as a visitor' do
+    it 'displays all deceased characters for the active campaign' do
+      campaign = create(:campaign)
+      user = create(:user)
+      dead_1 = create(:dead_character, user: user, campaign: campaign)
+      dead_2 = create(:dead_character, user: user, campaign: campaign)
+      alive = create(:character, user: user, campaign: campaign)
+
+      visit '/hall-of-heroes'
+
+      expect(page).to have_content(dead_1.name)
+      expect(page).to have_content(dead_2.name)
+      expect(page).to_not have_content(alive.name)
+    end
+  end
+end

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -41,5 +41,17 @@ RSpec.describe Campaign, type: :model do
 
       expect(campaign.latest_high_res).to eq(map3.high_res)
     end
+
+    it '#heroes' do
+      campaign = create(:campaign)
+      user = create(:user)
+      dead_1 = create(:dead_character, user: user, campaign: campaign)
+      dead_2 = create(:dead_character, user: user, campaign: campaign)
+      alive = create(:character, user: user)
+
+      expect(campaign.heroes).to include(dead_1)
+      expect(campaign.heroes).to include(dead_2)
+      expect(campaign.heroes).to_not include(alive)
+    end
   end
 end

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -101,7 +101,6 @@ RSpec.describe Character, type: :model do
       expect(character.status).to eq('dead')
       expect(character.alive?).to be(false)
     end
-
   end
 
   describe 'default properties' do
@@ -131,8 +130,8 @@ RSpec.describe Character, type: :model do
     it '.dead' do
       campaign = create(:campaign)
       user = create(:user)
-      dead_1 = create(:dead_character, user: user)
-      dead_2 = create(:dead_character, user: user)
+      dead_1 = create(:dead_character, user: user, campaign: campaign)
+      dead_2 = create(:dead_character, user: user, campaign: campaign)
       alive = create(:character, user: user)
 
       result = Character.dead

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -85,6 +85,25 @@ RSpec.describe Character, type: :model do
     end
   end
 
+  describe 'roles' do
+    it 'starts out as alive' do
+      user = create(:user)
+      character = create(:character, user: user)
+
+      expect(character.status).to eq('alive')
+      expect(character.alive?).to be_truthy
+    end
+
+    it 'we can have a dead character' do
+      user = create(:user)
+      character = create(:dead_character, user: user)
+
+      expect(character.status).to eq('dead')
+      expect(character.alive?).to be(false)
+    end
+
+  end
+
   describe 'default properties' do
     it 'sets appropriate default values when creating a character' do
       user = create(:user)
@@ -106,6 +125,20 @@ RSpec.describe Character, type: :model do
       result = Character.active
       expect(result.first).to eq(char1)
       expect(result.last).to eq(char2)
+      expect(result.count).to eq(2)
+    end
+
+    it '.dead' do
+      campaign = create(:campaign)
+      user = create(:user)
+      dead_1 = create(:dead_character, user: user)
+      dead_2 = create(:dead_character, user: user)
+      alive = create(:character, user: user)
+
+      result = Character.dead
+      expect(result).to include(dead_1)
+      expect(result).to include(dead_2)
+      expect(result).to_not include(alive)
       expect(result.count).to eq(2)
     end
   end


### PR DESCRIPTION
Closes #99 

Adds a status enum to character to designate if they are alive or not. By default characters are alive. 

Adds a scope to character to get dead characters, and adds an instance method for a campaign to get the campaign's heroes. 